### PR TITLE
Remove unneeded Maven dependency and replace deprecated calls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,21 +17,12 @@
 			<artifactId>paper-api</artifactId>
 			<version>1.15.2-R0.1-SNAPSHOT</version>
 		</dependency>
-		<dependency>
-			<groupId>com.comphenix.protocol</groupId>
-			<artifactId>ProtocolLib</artifactId>
-			<version>4.4.0</version>
-        </dependency>
 	</dependencies>
 
 	<repositories>
 		<repository>
 			<id>papermc</id>
 			<url>https://papermc.io/repo/repository/maven-public/</url>
-		</repository>
-		<repository>
-			<id>dmulloy2-repo</id>
-			<url>http://repo.dmulloy2.net/content/groups/public/</url>
 		</repository>
 	</repositories>
 

--- a/src/main/java/pw/kaboom/extras/modules/player/PlayerTeleport.java
+++ b/src/main/java/pw/kaboom/extras/modules/player/PlayerTeleport.java
@@ -1,5 +1,6 @@
 package pw.kaboom.extras.modules.player;
 
+import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -13,10 +14,10 @@ public final class PlayerTeleport implements Listener {
 	void onPlayerChangedWorld(final PlayerChangedWorldEvent event) {
 		final Player player = event.getPlayer();
 
-		if (player.getMaxHealth() <= 0) {
-			player.setMaxHealth(Double.POSITIVE_INFINITY);
+		if (player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue() <= 0) {
+			player.getAttribute(Attribute.GENERIC_MAX_HEALTH).setBaseValue(Double.POSITIVE_INFINITY);
 			player.setHealth(20);
-			player.setMaxHealth(20);
+			player.getAttribute(Attribute.GENERIC_MAX_HEALTH).setBaseValue(20);
 		}
 	}
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: Extras
 main: pw.kaboom.extras.Main
 description: Plugin that adds extra functionality to the server.
-api-version: 1.13
+api-version: 1.16
 version: master
 
 commands:


### PR DESCRIPTION
Please ensure that whatever exploit you were patching in PlayerTeleport.java remains patched even with these changes.