### PR TITLE
Prevent usage of @ selectors with spreadplayers

### DIFF
--- a/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
+++ b/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
@@ -155,7 +155,9 @@ public final class ServerCommand implements Listener {
 					break;
 				case "/minecraft:spreadplayers":
 				case "/spreadplayers":
-					if (arr.length >= 5) {
+					if (arr.length == 7 && arr[6].contains("@")) {
+						return "cancel";
+					} else if (arr.length >= 5) {
 						if (Double.parseDouble(arr[3]) > 0) {
 							arr[3] = "0";
 						}


### PR DESCRIPTION
Players/Bots have been spamming /spreadplayers with @e/@a and causing lag. When this is going on the server is basically unresponsive. 