### PR TITLE
Improved execute as/at/facing detection

### DIFF
--- a/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
+++ b/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
@@ -12,6 +12,8 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.server.ServerCommandEvent;
 
 public final class ServerCommand implements Listener {
+	private static Pattern asAtPattern = Pattern.compile("\\b(as|at|facing entity) @[ae]\\b");
+
 	public static boolean checkExecuteCommand(final String cmd) {
 		return ("execute".equalsIgnoreCase(cmd)
 			|| "banlist".equalsIgnoreCase(cmd)
@@ -81,7 +83,6 @@ public final class ServerCommand implements Listener {
 				case "/execute":
 					if (arr.length >= 2) {
 						int asAtCount = 0;
-						Pattern asAtPattern = Pattern.compile("\\b(as|at|facing entity) @[ae]\\b");
 						Matcher asAtMatcher = asAtPattern.matcher(command.toLowerCase());
 						while (asAtMatcher.find()) {
 							asAtCount++;

--- a/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
+++ b/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
@@ -1,5 +1,8 @@
 package pw.kaboom.extras.modules.server;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.bukkit.block.CommandBlock;
 import org.bukkit.command.BlockCommandSender;
 import org.bukkit.command.CommandSender;
@@ -78,6 +81,14 @@ public final class ServerCommand implements Listener {
 				case "/execute":
 					if (arr.length >= 2) {
 						int asAtCount = 0;
+						Pattern asAtPattern = Pattern.compile("\\b(as|at|facing entity) @[ae]\\b");
+						Matcher asAtMatcher = asAtPattern.matcher(command.toLowerCase());
+						while (asAtMatcher.find()) {
+							asAtCount++;
+						}
+						if (asAtCount >= 2) {
+							return "cancel";
+						}
 
 						for (int i = 1; i < arr.length; i++) {
 							if ("run".equalsIgnoreCase(arr[i])) {
@@ -109,14 +120,6 @@ public final class ServerCommand implements Listener {
 								}
 								break;
 							}
-
-							if ("as".equalsIgnoreCase(arr[i]) || "at".equalsIgnoreCase(arr[i]) || "facing".equalsIgnoreCase(arr[i])) {
-								asAtCount++;
-							}
-						}
-
-						if (asAtCount >= 2) {
-							return "cancel";
 						}
 					}
 					break;


### PR DESCRIPTION
As I understand it, having multiple as/at/facing in an execute command can be dangerous because it can exponentially multiply the selected targets, causing the server to lag or even crash.

However,
`/execute as @a as @a ...` is dangerous
but
`/execute as @p at @s ...` is not dangerous.

I changed it so that it will only cancel the command when it detects as/at/facing followed by `@a` or `@e` more than once. The selectors `@p`, `@r`, and `@s` will not cause targets to multiply.