### PR TITLE
Fixed tab completion for vanilla /deop and /op commands

### DIFF
--- a/src/main/java/pw/kaboom/extras/Main.java
+++ b/src/main/java/pw/kaboom/extras/Main.java
@@ -36,6 +36,7 @@ import pw.kaboom.extras.modules.player.PlayerInteract;
 import pw.kaboom.extras.modules.player.PlayerRecipe;
 import pw.kaboom.extras.modules.player.PlayerTeleport;
 import pw.kaboom.extras.modules.server.ServerCommand;
+import pw.kaboom.extras.modules.server.ServerTabComplete;
 import pw.kaboom.extras.modules.server.ServerTick;
 
 public final class Main extends JavaPlugin {
@@ -97,6 +98,7 @@ public final class Main extends JavaPlugin {
 
 		/* Server-related modules */
 		this.getServer().getPluginManager().registerEvents(new ServerCommand(), this);
+		this.getServer().getPluginManager().registerEvents(new ServerTabComplete(), this);
 		this.getServer().getPluginManager().registerEvents(new ServerTick(), this);
 	}
 

--- a/src/main/java/pw/kaboom/extras/modules/player/PlayerConnection.java
+++ b/src/main/java/pw/kaboom/extras/modules/player/PlayerConnection.java
@@ -20,6 +20,7 @@ import com.destroystokyo.paper.profile.ProfileProperty;
 import com.google.common.base.Charsets;
 
 import pw.kaboom.extras.Main;
+import pw.kaboom.extras.modules.server.ServerTabComplete;
 
 public final class PlayerConnection implements Listener {
 	@EventHandler
@@ -61,6 +62,8 @@ public final class PlayerConnection implements Listener {
 				fadeOut
 			);
 		}
+
+		ServerTabComplete.getLoginNameList().put(player.getUniqueId(), player.getName());
 	}
 
 	@EventHandler
@@ -105,6 +108,7 @@ public final class PlayerConnection implements Listener {
 	void onPlayerQuit(final PlayerQuitEvent event) {
 		PlayerCommand.getCommandMillisList().remove(event.getPlayer().getUniqueId());
 		//PlayerInteract.interactMillisList.remove(event.getPlayer().getUniqueId());
+		ServerTabComplete.getLoginNameList().remove(event.getPlayer().getUniqueId());
 	}
 
 	@EventHandler

--- a/src/main/java/pw/kaboom/extras/modules/server/ServerTabComplete.java
+++ b/src/main/java/pw/kaboom/extras/modules/server/ServerTabComplete.java
@@ -1,0 +1,75 @@
+package pw.kaboom.extras.modules.server;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+import com.destroystokyo.paper.event.server.AsyncTabCompleteEvent;
+
+public final class ServerTabComplete implements Listener {
+	private static HashMap<UUID, String> loginNameList = new HashMap<UUID, String>();
+
+	@EventHandler
+	void onAsyncTabComplete(final AsyncTabCompleteEvent event) {
+		final String[] arr = event.getBuffer().split(" ", 2);
+
+		// Vanilla clients will not send tab complete requests on the first word, but modified or bot clients may
+		if (arr.length < 2) {
+			return;
+		}
+
+		String command = arr[0];
+		String argsFragment = arr[1];
+		if (command.startsWith("/")) {
+			command = command.substring(1);
+		}
+
+		if (command.equalsIgnoreCase("op")) {
+			event.setCompletions(getOpCompletions(argsFragment));
+		} else if (command.equalsIgnoreCase("deop")) {
+			event.setCompletions(getDeopCompletions(argsFragment));
+		} else {
+			return;
+		}
+
+		if (event.getCompletions().size() == 0) {
+			event.setCancelled(true);
+		}
+	}
+
+	static List<String> getOpCompletions(final String argsFragment) {
+		ArrayList<String> deops = new ArrayList<String>();
+		for (Player player : Bukkit.getOnlinePlayers()) {
+			if (!player.isOp()) {
+				String loginName = loginNameList.get(player.getUniqueId());
+				if (loginName != null && loginName.startsWith(argsFragment)) {
+					deops.add(loginName);
+				}
+			}
+		}
+		return deops;
+	}
+
+	static List<String> getDeopCompletions(final String argsFragment) {
+		ArrayList<String> ops = new ArrayList<String>();
+		for (Player player : Bukkit.getOnlinePlayers()) {
+			if (player.isOp()) {
+				String loginName = loginNameList.get(player.getUniqueId());
+				if (loginName != null && loginName.startsWith(argsFragment)) {
+					ops.add(loginName);
+				}
+			}
+		}
+		return ops;
+	}
+
+	public static HashMap<UUID, String> getLoginNameList() {
+		return loginNameList;
+	}
+}


### PR DESCRIPTION
The vanilla /deop and /op commands, by default, will allow you to op or deop any player that the server has recorded, whether they are online or offline. Tab completion for the /deop command lists all of the server's ops and tab completion for the /op command lists all of the server's non-ops.

Normally, the vanilla tab completion should correctly return the list of deop-able or op-able usernames. However, the /username command throws a wrench into the operations. Vanilla commands seem to reference their own player list that is independent of Bukkit's player list. Despite the fact that any commands from plugins will generally listen to the player's new username, vanilla commands only care about their original names upon login. Tab completion, however, shows inconsistent behavior after username changes. It generally seems to show the players' updated names. Factor in how it's also trying to show offline players, and you can end up with a mess like this after a while:
![2021-07-07_23 12 25](https://user-images.githubusercontent.com/16061763/125013115-dca84780-e030-11eb-94c9-ab749dfd937b.png)

To most closely mimic the intended behavior of the vanilla Minecraft tab completion, I could scan the existing player data and ops list from the filesystem to get the correct names used by the vanilla commands. However, this would be both unnecessarily complex and inefficient, especially considering how Kaboom automatically ops players upon login, making it meaningless to op or deop offline players.

Instead, I wrote a bit of code that keeps track of the login names of players and shows the correct tab completions for online ops or deops. This way, not only will the server avoid sending enormous tab-completion lists, but the tab-completion entries will actually be valid for the command.

I was originally considering doing this for all vanilla commands that target players, but apparently, since commands other than deop and op only target online players, the vanilla client doesn't even bother to query the server for tab-completion options, so it can't be fixed the same way.