### PR TITLE
Upgrade paper-api to 1.16.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>com.destroystokyo.paper</groupId>
 			<artifactId>paper-api</artifactId>
-			<version>1.15.2-R0.1-SNAPSHOT</version>
+			<version>1.16.5-R0.1-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
This allows people to use new hex chat colors (`&#ABCDEF`) in both chat and /bcraw.