### PR TITLE
fix crash in paper when removing entities

### DIFF
--- a/src/main/java/pw/kaboom/extras/Main.java
+++ b/src/main/java/pw/kaboom/extras/Main.java
@@ -42,16 +42,8 @@ import pw.kaboom.extras.modules.server.ServerTabComplete;
 import pw.kaboom.extras.modules.server.ServerTick;
 
 public final class Main extends JavaPlugin {
-	private static Main plugin;
-
-	public static Main getInstance() {
-		return plugin;
-	}
-
 	@Override
 	public void onLoad() {
-		plugin = this;
-
 		/* Fill lists */
 		Collections.addAll(
 				BlockPhysics.getBlockFaces(),

--- a/src/main/java/pw/kaboom/extras/Main.java
+++ b/src/main/java/pw/kaboom/extras/Main.java
@@ -42,8 +42,16 @@ import pw.kaboom.extras.modules.server.ServerTabComplete;
 import pw.kaboom.extras.modules.server.ServerTick;
 
 public final class Main extends JavaPlugin {
+	private static Main plugin;
+
+	public static Main getInstance() {
+		return plugin;
+	}
+
 	@Override
 	public void onLoad() {
+		plugin = this;
+
 		/* Fill lists */
 		Collections.addAll(
 				BlockPhysics.getBlockFaces(),

--- a/src/main/java/pw/kaboom/extras/modules/entity/EntitySpawn.java
+++ b/src/main/java/pw/kaboom/extras/modules/entity/EntitySpawn.java
@@ -35,7 +35,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import pw.kaboom.extras.Main;
 
 public final class EntitySpawn implements Listener {
-	private static final Main plugin = JavaPlugin.getPlugin(Main.class);
+	private static final Main PLUGIN = JavaPlugin.getPlugin(Main.class);
 
 	private void applyEntityChanges(final Entity entity) {
 		switch (entity.getType()) {
@@ -347,6 +347,6 @@ public final class EntitySpawn implements Listener {
 	}
 
 	public void removeEntitySafely(final Entity entity) {
-		Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, entity::remove);
+		Bukkit.getScheduler().scheduleSyncDelayedTask(PLUGIN, entity::remove);
 	}
 }

--- a/src/main/java/pw/kaboom/extras/modules/entity/EntitySpawn.java
+++ b/src/main/java/pw/kaboom/extras/modules/entity/EntitySpawn.java
@@ -30,6 +30,7 @@ import com.destroystokyo.paper.event.block.TNTPrimeEvent;
 import com.destroystokyo.paper.event.entity.EntityAddToWorldEvent;
 import com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent;
 import com.destroystokyo.paper.event.entity.PreSpawnerSpawnEvent;
+import pw.kaboom.extras.Main;
 
 public final class EntitySpawn implements Listener {
 	private void applyEntityChanges(final Entity entity) {
@@ -55,7 +56,7 @@ public final class EntitySpawn implements Listener {
 		if (worldEntityCount > 1024) {
 			for (Entity entity : world.getEntities()) {
 				if (!EntityType.PLAYER.equals(entity.getType())) {
-					entity.remove();
+					removeEntitySafely(entity);
 				}
 			}
 			return true;
@@ -185,7 +186,7 @@ public final class EntitySpawn implements Listener {
 			final double z = entity.getLocation().getZ();
 
 			if (isOutsideBoundaries(x, y, z)) {
-				entity.remove();
+				removeEntitySafely(entity);
 				return;
 			}
 
@@ -195,7 +196,7 @@ public final class EntitySpawn implements Listener {
 
 			if (isEntityLimitReached(entityType, chunk, world, isAddToWorldEvent)
 					&& !EntityType.PLAYER.equals(entity.getType())) {
-				entity.remove();
+				removeEntitySafely(entity);
 				return;
 			}
 
@@ -339,5 +340,9 @@ public final class EntitySpawn implements Listener {
 			event.setCancelled(true);
 			return;
 		}
+	}
+
+	public void removeEntitySafely(final Entity entity) {
+		Main.getInstance().getServer().getScheduler().scheduleSyncDelayedTask(Main.getInstance(), entity::remove);
 	}
 }

--- a/src/main/java/pw/kaboom/extras/modules/entity/EntitySpawn.java
+++ b/src/main/java/pw/kaboom/extras/modules/entity/EntitySpawn.java
@@ -30,6 +30,7 @@ import com.destroystokyo.paper.event.block.TNTPrimeEvent;
 import com.destroystokyo.paper.event.entity.EntityAddToWorldEvent;
 import com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent;
 import com.destroystokyo.paper.event.entity.PreSpawnerSpawnEvent;
+import org.bukkit.plugin.java.JavaPlugin;
 import pw.kaboom.extras.Main;
 
 public final class EntitySpawn implements Listener {
@@ -343,6 +344,6 @@ public final class EntitySpawn implements Listener {
 	}
 
 	public void removeEntitySafely(final Entity entity) {
-		Main.getInstance().getServer().getScheduler().scheduleSyncDelayedTask(Main.getInstance(), entity::remove);
+		JavaPlugin.getPlugin(Main.class).getServer().getScheduler().scheduleSyncDelayedTask(JavaPlugin.getPlugin(Main.class), entity::remove);
 	}
 }

--- a/src/main/java/pw/kaboom/extras/modules/entity/EntitySpawn.java
+++ b/src/main/java/pw/kaboom/extras/modules/entity/EntitySpawn.java
@@ -2,6 +2,7 @@ package pw.kaboom.extras.modules.entity;
 
 import java.util.Random;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -34,6 +35,8 @@ import org.bukkit.plugin.java.JavaPlugin;
 import pw.kaboom.extras.Main;
 
 public final class EntitySpawn implements Listener {
+	private static final Main plugin = JavaPlugin.getPlugin(Main.class);
+
 	private void applyEntityChanges(final Entity entity) {
 		switch (entity.getType()) {
 			case AREA_EFFECT_CLOUD:
@@ -344,6 +347,6 @@ public final class EntitySpawn implements Listener {
 	}
 
 	public void removeEntitySafely(final Entity entity) {
-		JavaPlugin.getPlugin(Main.class).getServer().getScheduler().scheduleSyncDelayedTask(JavaPlugin.getPlugin(Main.class), entity::remove);
+		Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, entity::remove);
 	}
 }


### PR DESCRIPTION
https://github.com/PaperMC/Paper/issues/6451

after testing for 5mins this did in fact seem to fix it

this breaks, for instance, custom maps that come with entities in them that extras then tries to remove. i had my server crashing every like 1-3 minutes after each startup due to this.