### PR TITLE
block /scissors reload

### DIFF
--- a/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
+++ b/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
@@ -206,7 +206,7 @@ public final class ServerCommand implements Listener {
                 case "/scissors":
                     if(arr.length >= 2
                            && "reload".equalsIgnoreCase(arr[1])) {
-                        return "cancel":
+                        return "cancel";
                     }
                     break;
                 case "/geyser-spigot:geyser":

--- a/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
+++ b/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
@@ -202,6 +202,13 @@ public final class ServerCommand implements Listener {
                         return "cancel";
                     }
                     break;
+                case "/scissors:scissors":
+                case "/scissors":
+                    if(arr.length >= 2
+                           && "reload".equalsIgnoreCase(arr[1])) {
+                        return "cancel":
+                    }
+                    break;
                 case "/geyser-spigot:geyser":
                 case "/geyser":
                     if (arr.length >= 2


### PR DESCRIPTION
Yeah this is another one of those "spam a random command until it breaks the server" This only applies to servers which actually run scissors, which to my knowledge kaboom and all clones all run Scissors.
This is best affective when sudoing everyone to run it when theres a lot of people online
![image](https://files.kitsune.icu/selif/9seb7j2f.png)