### PR TITLE
Block /fawe debugpaste

### DIFF
--- a/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
+++ b/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
@@ -216,6 +216,14 @@ public final class ServerCommand implements Listener {
                         return "cancel";
                     }
                     break;
+                case "/fastasyncworldedit:fawe":
+                case "/fawe":
+                case "/worldedit":
+                    if (arr.length >= 2
+                            && "debugpaste".equalsIgnoreCase(arr[1])) {
+                        return "cancel";
+                    }
+                    break;
                 default:
                     break;
             }


### PR DESCRIPTION
/fawe debugpaste can be used to get information that should not be attainable to the public, such as latest.log, config.yml (for FAWE), worldedit-config.yml and other information, such as server and plugin info.
![image](https://files.kitsune.icu/selif/a1imjgdp.png) ![image](https://files.kitsune.icu/selif/rpx1dfvf.png)
Thanks to ChipMC for bringing this to my attention.