### PR TITLE
Unblock `selector` in some commands

### DIFF
--- a/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
+++ b/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
@@ -178,14 +178,8 @@ public final class ServerCommand implements Listener {
                         return String.join(" ", arr);
                     }
                     break;
-                case "/minecraft:bossbar":
                 case "/minecraft:setblock":
-                case "/minecraft:tellraw":
-                case "/minecraft:title":
-                case "/bossbar":
                 case "/setblock":
-                case "/tellraw":
-                case "/title":
                     final String charCommand = parseCharCodes(command);
                     if (charCommand.contains("selector")) {
                         return "cancel";


### PR DESCRIPTION
Scissors limits JSON components more than enough to patch the kick exploit, and selectors are allowed in `say` anyway. `selector` components can be useful in some cases, and it is annoying to be unable to have `selector` in text. Also, the restriction probably makes it impossible to create bossbars with `selector` in their names.