### PR TITLE
Replace string concatenation with appending text components

### DIFF
--- a/src/main/java/pw/kaboom/extras/commands/CommandJumpscare.java
+++ b/src/main/java/pw/kaboom/extras/commands/CommandJumpscare.java
@@ -46,15 +46,20 @@ public final class CommandJumpscare implements CommandExecutor {
         final Player target = Bukkit.getPlayer(args[0]);
 
         if (target == null) {
-            sender.sendMessage(Component
-                    .text("Player \"" + args[0] + "\" not found"));
+            sender.sendMessage(
+                Component.text("Player \"")
+                .append(Component.text(args[0]))
+                .append(Component.text("\" not found"))
+            );
             return true;
         }
 
         createJumpscare(target);
-        sender.sendMessage(Component
-                .text("Successfully created jumpscare for player \""
-                        + target.getName() + "\""));
+        sender.sendMessage(
+            Component.text("Successfully created jumpscare for player \"")
+            .append(Component.text(target.getName()))
+            .append(Component.text("\""))
+        );
         return true;
     }
 }

--- a/src/main/java/pw/kaboom/extras/commands/CommandJumpscare.java
+++ b/src/main/java/pw/kaboom/extras/commands/CommandJumpscare.java
@@ -48,8 +48,8 @@ public final class CommandJumpscare implements CommandExecutor {
         if (target == null) {
             sender.sendMessage(
                 Component.text("Player \"")
-                .append(Component.text(args[0]))
-                .append(Component.text("\" not found"))
+                    .append(Component.text(args[0]))
+                    .append(Component.text("\" not found"))
             );
             return true;
         }
@@ -57,8 +57,8 @@ public final class CommandJumpscare implements CommandExecutor {
         createJumpscare(target);
         sender.sendMessage(
             Component.text("Successfully created jumpscare for player \"")
-            .append(Component.text(target.getName()))
-            .append(Component.text("\""))
+                .append(Component.text(target.getName()))
+                .append(Component.text("\""))
         );
         return true;
     }

--- a/src/main/java/pw/kaboom/extras/commands/CommandPumpkin.java
+++ b/src/main/java/pw/kaboom/extras/commands/CommandPumpkin.java
@@ -41,8 +41,8 @@ public final class CommandPumpkin implements CommandExecutor {
         if (target == null) {
             sender.sendMessage(
                 Component.text("Player \"")
-                .append(Component.text(args[0]))
-                .append(Component.text("\" not found"))
+                    .append(Component.text(args[0]))
+                    .append(Component.text("\" not found"))
             );
             return true;
         }
@@ -50,8 +50,8 @@ public final class CommandPumpkin implements CommandExecutor {
         placePumpkin(target);
         sender.sendMessage(
             Component.text("Player \"")
-            .append(Component.text(target.getName()))
-            .append(Component.text("\" is now a pumpkin"))
+                .append(Component.text(target.getName()))
+                .append(Component.text("\" is now a pumpkin"))
         );
         return true;
     }

--- a/src/main/java/pw/kaboom/extras/commands/CommandPumpkin.java
+++ b/src/main/java/pw/kaboom/extras/commands/CommandPumpkin.java
@@ -32,19 +32,27 @@ public final class CommandPumpkin implements CommandExecutor {
             for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
                 placePumpkin(onlinePlayer);
             }
-            sender.sendMessage("Everyone is now a pumpkin");
+            sender.sendMessage(Component.text("Everyone is now a pumpkin"));
             return true;
         }
 
         final Player target = Bukkit.getPlayer(args[0]);
 
         if (target == null) {
-            sender.sendMessage("Player \"" + args[0] + "\" not found");
+            sender.sendMessage(
+                Component.text("Player \"")
+                .append(Component.text(args[0]))
+                .append(Component.text("\" not found"))
+            );
             return true;
         }
 
         placePumpkin(target);
-        sender.sendMessage("Player \"" + target.getName() + "\" is now a pumpkin");
+        sender.sendMessage(
+            Component.text("Player \"")
+            .append(Component.text(target.getName()))
+            .append(Component.text("\" is now a pumpkin"))
+        );
         return true;
     }
 }

--- a/src/main/java/pw/kaboom/extras/commands/CommandUsername.java
+++ b/src/main/java/pw/kaboom/extras/commands/CommandUsername.java
@@ -64,8 +64,11 @@ public final class CommandUsername implements CommandExecutor {
         player.setPlayerProfile(profile);
         millis = System.currentTimeMillis();
 
-        player.sendMessage(Component
-                .text("Successfully set your username to \"" + name + "\""));
+        player.sendMessage(
+            Component.text("Successfully set your username to \"")
+                .append(Component.text(name))
+                .append(Component.text("\""))
+        );
         return true;
     }
 }

--- a/src/main/java/pw/kaboom/extras/helpers/SkinDownloader.java
+++ b/src/main/java/pw/kaboom/extras/helpers/SkinDownloader.java
@@ -15,6 +15,8 @@ import org.bukkit.scheduler.BukkitRunnable;
 import com.destroystokyo.paper.profile.PlayerProfile;
 import com.destroystokyo.paper.profile.ProfileProperty;
 
+import net.kyori.adventure.text.Component;
+
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
@@ -40,7 +42,11 @@ public final class SkinDownloader {
                     profile.setProperty(new ProfileProperty("textures", texture, signature));
 
                     if (shouldSendMessage) {
-                        player.sendMessage("Successfully set your skin to " + name + "'s");
+                        player.sendMessage(
+                            Component.text("Successfully set your skin to ")
+                            .append(Component.text(name))
+                            .append(Component.text("'s"))
+                        );
                     }
                 } catch (Exception exception) {
                     try {
@@ -50,7 +56,8 @@ public final class SkinDownloader {
                     }
 
                     if (shouldSendMessage) {
-                        player.sendMessage("A player with that username doesn't exist");
+                        player.sendMessage(Component
+                            .text("A player with that username doesn't exist"));
                     }
 
                     return;

--- a/src/main/java/pw/kaboom/extras/helpers/SkinDownloader.java
+++ b/src/main/java/pw/kaboom/extras/helpers/SkinDownloader.java
@@ -44,8 +44,8 @@ public final class SkinDownloader {
                     if (shouldSendMessage) {
                         player.sendMessage(
                             Component.text("Successfully set your skin to ")
-                            .append(Component.text(name))
-                            .append(Component.text("'s"))
+                                .append(Component.text(name))
+                                .append(Component.text("'s"))
                         );
                     }
                 } catch (Exception exception) {


### PR DESCRIPTION
This prevents legacy `§` color codes from leaking out of usernames.