### PR TITLE
Unblock `summon` in execute

### DIFF
--- a/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
+++ b/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
@@ -37,7 +37,6 @@ public final class ServerCommand implements Listener {
             || "say".equalsIgnoreCase(cmd)
             || "spreadplayers".equalsIgnoreCase(cmd)
             || "stop".equalsIgnoreCase(cmd)
-            || "summon".equalsIgnoreCase(cmd)
             || "teammsg".equalsIgnoreCase(cmd)
             || "teleport".equalsIgnoreCase(cmd)
             || "tell".equalsIgnoreCase(cmd)


### PR DESCRIPTION
This was likely added because of kaboomserver/server#41, but I was unable to reproduce that, even with many other entities existing (with `summon` unblocked).