### PR TITLE
Use adventure for death messages

### DIFF
--- a/src/main/java/pw/kaboom/extras/modules/player/PlayerDamage.java
+++ b/src/main/java/pw/kaboom/extras/modules/player/PlayerDamage.java
@@ -52,7 +52,7 @@ public final class PlayerDamage implements Listener {
         final Player player = event.getEntity();
 
         for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
-            onlinePlayer.sendMessage(event.getDeathMessage());
+            onlinePlayer.sendMessage(event.deathMessage());
         }
 
         try {


### PR DESCRIPTION
This improves the quality of the death messages a lot. Translatable text, hover events, and possibly other things are no longer lost, and legacy color codes, such as in the username, no longer leak out into the rest of the message.