### PR TITLE
Append new text components instead of concatenating strings (again)

### DIFF
--- a/src/main/java/pw/kaboom/extras/commands/CommandDestroyEntities.java
+++ b/src/main/java/pw/kaboom/extras/commands/CommandDestroyEntities.java
@@ -35,9 +35,13 @@ public final class CommandDestroyEntities implements CommandExecutor {
             worldCount++;
         }
 
-        sender.sendMessage(Component.text(
-                "Successfully destroyed " + entityCount + " entities in "
-                        + worldCount + " worlds"));
+        sender.sendMessage(
+            Component.text("Successfully destroyed ")
+                .append(Component.text(entityCount))
+                .append(Component.text(" entities in "))
+                .append(Component.text(worldCount))
+                .append(Component.text(" worlds"))
+        );
         return true;
     }
 }

--- a/src/main/java/pw/kaboom/extras/commands/CommandPing.java
+++ b/src/main/java/pw/kaboom/extras/commands/CommandPing.java
@@ -54,8 +54,12 @@ public final class CommandPing implements CommandExecutor {
                 break;
         }
 
-        sender.sendMessage(Component.text((args.length == 0 ?
-                        "Your" : target.getName() + "'s") + " ping is ")
+        Component namePrefix = args.length == 0
+            ? Component.text("Your")
+            : Component.text(target.getName()).append(Component.text("'s"));
+
+        sender.sendMessage(namePrefix
+                .append(Component.text(" ping is "))
                 .append(Component.text(ping, highlighting))
                 .append(Component.text("ms.", highlighting)));
         return true;


### PR DESCRIPTION
I missed some commands in the first PR. Also, I am aware that the integers in `destroyentities` cannot have legacy color codes, but I did it there anyway, for consistency reasons.