### PR TITLE
Prevent players who are muted and deopped from using commands such as `me`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,12 +18,24 @@
             <version>1.18.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>net.essentialsx</groupId>
+            <artifactId>EssentialsX</artifactId>
+            <version>2.19.7</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <repositories>
         <repository>
             <id>papermc</id>
             <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+
+        <repository>
+            <id>essentialsx</id>
+            <url>https://repo.essentialsx.net/releases/</url>
         </repository>
     </repositories>
 

--- a/src/main/java/pw/kaboom/extras/helpers/PlayerMuting.java
+++ b/src/main/java/pw/kaboom/extras/helpers/PlayerMuting.java
@@ -1,0 +1,16 @@
+package pw.kaboom.extras.helpers;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import com.earth2me.essentials.IEssentials;
+
+public class PlayerMuting {
+    private static IEssentials essentials = (IEssentials) Bukkit.getServer()
+        .getPluginManager()
+        .getPlugin("Essentials");
+
+    public static boolean isMuted(Player player) {
+        return essentials != null && essentials.getUser(player).isMuted();
+    } 
+}

--- a/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
+++ b/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
@@ -14,6 +14,9 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.server.ServerCommandEvent;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.entity.Player;
+
+import pw.kaboom.extras.helpers.PlayerMuting;
 
 import pw.kaboom.extras.Main;
 
@@ -200,6 +203,22 @@ public final class ServerCommand implements Listener {
                         return "cancel";
                     }
                     break;
+                case "/minecraft:say":
+                case "/minecraft:me":
+                case "/minecraft:tell":
+                case "/minecraft:msg":
+                case "/minecraft:w":
+                case "/say":
+                case "/me":
+                case "/tell":
+                case "/msg":
+                case "/w":
+                    if (isConsoleCommand) break;
+                    Player player = (Player) sender;
+
+                    if (!player.isOp() && PlayerMuting.isMuted(player)) {
+                        return "cancel";
+                    }
                 default:
                     break;
             }


### PR DESCRIPTION
Closes kaboomserver/server#46. Note that this only prevents such commands for players who are deopped AND muted, as opped players can "circumvent" being muted in many other ways.