### PR TITLE
Append to an empty component instead of the prefix

### DIFF
--- a/src/main/java/pw/kaboom/extras/modules/player/PlayerPrefix.java
+++ b/src/main/java/pw/kaboom/extras/modules/player/PlayerPrefix.java
@@ -92,10 +92,11 @@ public class PlayerPrefix implements Listener {
 	}
 
 	private static void onUpdate(Player player) throws IOException {
-		final Component prefix = getPrefix(player);
-		final Component displayName = player.displayName();
+		final Component component = Component.empty()
+			.append(getPrefix(player))
+			.append(player.displayName());
 
-		player.playerListName(prefix.append(displayName));
+		player.playerListName(component);
 	}
 
 	@EventHandler(priority = EventPriority.MONITOR)


### PR DESCRIPTION
This fixes formatting from some prefixes, such as `&kobfuscated`, leaking into the display name.