### PR TITLE
Make the taken username check more accurate

### DIFF
--- a/src/main/java/pw/kaboom/extras/commands/CommandUsername.java
+++ b/src/main/java/pw/kaboom/extras/commands/CommandUsername.java
@@ -55,7 +55,9 @@ public final class CommandUsername implements CommandExecutor {
             return true;
         }
 
-        if (Bukkit.getPlayer(name) != null) {
+        for (Player other : Bukkit.getOnlinePlayers()) {
+            if (!other.getName().equals(name)) continue;
+
             player.sendMessage(Component
                     .text("A player with that username is already logged in."));
             return true;


### PR DESCRIPTION
Instead of using `Bukkit.getPlayer(name)`, now each player is manually iterated over to check if a username is taken. This fixes multiple problems, such as a player not being able to set their name to `a` because a player named `ab` is online, and a player not being able to set their username back to the one they joined with.