### PR TITLE
Attempt to improve server performance under intense redstone load

### DIFF
--- a/src/main/java/pw/kaboom/extras/Main.java
+++ b/src/main/java/pw/kaboom/extras/Main.java
@@ -93,6 +93,8 @@ public final class Main extends JavaPlugin {
         this.getCommand("username").setExecutor(new CommandUsername());
 
         /* Block-related modules */
+        BlockPhysics.init(this);
+
         this.getServer().getPluginManager().registerEvents(new BlockCheck(), this);
         this.getServer().getPluginManager().registerEvents(new BlockPhysics(), this);
 

--- a/src/main/java/pw/kaboom/extras/modules/block/BlockPhysics.java
+++ b/src/main/java/pw/kaboom/extras/modules/block/BlockPhysics.java
@@ -16,12 +16,14 @@ import org.bukkit.event.block.BlockRedstoneEvent;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 
 import com.destroystokyo.paper.event.block.BlockDestroyEvent;
+import org.bukkit.scheduler.BukkitScheduler;
+import pw.kaboom.extras.Main;
 
 public final class BlockPhysics implements Listener {
 
     // This class contains code to prevent large areas of non-solid blocks
     // from crashing the server
-
+    private static double tps = 20;
     private static HashSet<BlockFace> blockFaces = new HashSet<BlockFace>();
 
     @EventHandler
@@ -141,7 +143,6 @@ public final class BlockPhysics implements Listener {
 
     @EventHandler
     void onBlockRedstone(final BlockRedstoneEvent event) {
-        final double tps = Bukkit.getServer().getTPS()[0];
         final int maxTps = 10;
 
         if (tps < maxTps) {
@@ -168,5 +169,17 @@ public final class BlockPhysics implements Listener {
 
     public static HashSet<BlockFace> getBlockFaces() {
         return blockFaces;
+    }
+
+    private static void updateTPS() {
+        final double[] tpsValues = Bukkit.getTPS();
+
+        tps = tpsValues[0];
+    }
+
+    public static void init(final Main main) {
+        final BukkitScheduler scheduler = Bukkit.getScheduler();
+
+        scheduler.runTaskTimer(main, BlockPhysics::updateTPS, 0L, 1200L); // 1 minute
     }
 }


### PR DESCRIPTION
Calling `Bukkit.getTPS()` on every BlockRedstoneEvent causes [noticeable lag](https://timings.aikar.co/dev/?id=ede7e20f7d334f2ca8a234c865d48864#plugins) under heavy redstone load.

This is due to the fact that redstone current changes occur multiple times every tick if enough redstone clocks are present.
So, I wrote [a plugin](https://github.com/allinkdev/RedstoneEventCounter) to measure how many times a BlockRedstoneEvent is called per tick, and tested it against redstone clock designs I have seen used on Kaboom, or used myself.

I am using the Alternate Current redstone implementation on this redstone test server, just like Kaboom.

### Repeater Clock

![image](https://user-images.githubusercontent.com/44676012/222954863-755ef643-0383-45d5-9290-ba6fc630116f.png)

### Redstone Torch Clock

![image](https://user-images.githubusercontent.com/44676012/222954959-fbca8c3f-a95c-452f-9464-9f4d958a5af7.png)

### Observer Clock

![image](https://user-images.githubusercontent.com/44676012/222955255-936dbdc2-b156-4efc-9d76-e14ec62c4062.png)

That's 12 calls maximum to `Bukkit.getTPS()`, and at the minimum, 4. Now, imagine for a moment, someone uses WorldEdit in order to stack a bunch of these clocks in every direction. That's much more than just 4-12 BlockRedstoneEvent executions, and by extension `Bukkit.getTPS()` calls, per tick.

In this pull request, [I fix this](https://timings.aikar.co/dev/?id=1d061012833c4206a87421c3b4c6e1ba#plugins) by using the BukkitScheduler to schedule a Runnable to get the 1-minute TPS average of `Bukkit.getTPS()` every minute.