### PR TITLE
Remove useless integer limit check

### DIFF
--- a/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
+++ b/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
@@ -71,24 +71,6 @@ public final class ServerCommand implements Listener {
             commandName = "/" + arr[1].toLowerCase();
         }
 
-        for (int i = 1; i < arr.length; i++) {
-            if (arr[i].matches("^[+-]?(?:\\d+\\.?\\d*|\\d*\\.?\\d+)[\\r\\n]*$")) {
-                try {
-                    int integer = Integer.parseInt(arr[i]);
-                    try {
-                        if (integer >= Integer.MAX_VALUE) {
-                            return "cancel";
-                        }
-                    } catch (Exception e) {
-                        return "cancel";
-                    }
-
-                } catch (NumberFormatException e) {
-                    // Ignore exception
-                }
-            }
-        }
-
         try {
             switch (commandName) {
                 case "/minecraft:execute":


### PR DESCRIPTION
Scissors has fixed most, if not all exploits relating to OOB coordinates. Removing this check should make the command check slightly faster.