### PR TITLE
Block /tick command in /execute

### DIFF
--- a/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
+++ b/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
@@ -26,7 +26,7 @@ public final class ServerCommand implements Listener {
     private static final String[] COMMANDS = { "execute", "clone", "fill", "forceload", "kick",
             "locate", "locatebiome", "me", "msg", "reload", "save-all", "say", "spreadplayers",
             "stop", "summon", "teammsg", "teleport", "tell", "tellraw", "tm", "tp", "w", "place",
-            "fillbiome", "ride" };
+            "fillbiome", "ride" , "tick"};
 
     public static boolean checkExecuteCommand(final String cmd) {
         for (String command : COMMANDS) {


### PR DESCRIPTION
Block `/execute` from being able to run `/tick`