### PR TITLE
Cache output of CPU model grabbing command

### DIFF
--- a/src/main/java/pw/kaboom/extras/util/Lazy.java
+++ b/src/main/java/pw/kaboom/extras/util/Lazy.java
@@ -1,0 +1,23 @@
+package pw.kaboom.extras.util;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Supplier;
+
+public final class Lazy<T> implements Supplier<T> {
+    private @Nullable T value;
+    private final Supplier<T> supplier;
+
+    public Lazy(final Supplier<T> supplier) {
+        this.supplier = supplier;
+    }
+
+    @Override
+    public T get() {
+        if (this.value == null) {
+            this.value = this.supplier.get();
+        }
+
+        return this.value;
+    }
+}


### PR DESCRIPTION
Unfortunately, the previous behavior of running the shell command every time the ServerInfo command can be easily abused with multiple command block loops, leading to noticeable lag.

Here, I cache the result of the CPU model grabbing command and run it *once* when needed.