### PR TITLE
Allow players to select the vanilla chat format

### DIFF
--- a/src/main/java/pw/kaboom/extras/modules/player/PlayerChat.java
+++ b/src/main/java/pw/kaboom/extras/modules/player/PlayerChat.java
@@ -41,6 +41,10 @@ public final class PlayerChat implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     void onAsyncChatEventRenderer(final AsyncChatEvent event) {
+        if (PlayerPrefix.isUsingVanillaFormat(event.getPlayer())) {
+            return;
+        }
+
         event.renderer(CHAT_RENDERER);
     }
 

--- a/src/main/java/pw/kaboom/extras/modules/player/PlayerChat.java
+++ b/src/main/java/pw/kaboom/extras/modules/player/PlayerChat.java
@@ -41,10 +41,6 @@ public final class PlayerChat implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     void onAsyncChatEventRenderer(final AsyncChatEvent event) {
-        if (PlayerPrefix.isUsingVanillaFormat(event.getPlayer())) {
-            return;
-        }
-
         event.renderer(CHAT_RENDERER);
     }
 
@@ -87,11 +83,24 @@ public final class PlayerChat implements Listener {
                 LegacyComponentSerializer
                         .legacyAmpersand();
 
+        private Component renderVanilla(@Nonnull Component displayName,
+                                        @Nonnull Component component) {
+            return Component.translatable(
+                    "chat.type.text",
+                    displayName,
+                    component.replaceText(URL_REPLACEMENT_CONFIG)
+            );
+        }
+
         @Override
         public @Nonnull Component render(@Nonnull Player player,
                                          @Nonnull Component displayName,
                                          @Nonnull Component component,
                                          @Nonnull Audience audience) {
+            if (PlayerPrefix.isUsingVanillaFormat(player)) {
+                return renderVanilla(displayName, component);
+            }
+
             Component newComponent = Component.empty();
             final Component prefix;
             Component prefix1;

--- a/src/main/java/pw/kaboom/extras/modules/player/PlayerPrefix.java
+++ b/src/main/java/pw/kaboom/extras/modules/player/PlayerPrefix.java
@@ -74,6 +74,14 @@ public final class PlayerPrefix implements Listener {
 		return prefix;
 	}
 
+	public static boolean isUsingVanillaFormat(Player player) {
+		final UUID playerUUID = player.getUniqueId();
+		final String stringifiedUUID = playerUUID.toString();
+		final String legacyPrefix = PREFIX_CONFIG.getString(stringifiedUUID);
+
+		return legacyPrefix != null && legacyPrefix.equals("%");
+	}
+
 	public static Component getPrefix(Player player) throws IOException {
 		final UUID playerUUID = player.getUniqueId();
 		final String stringifiedUUID = playerUUID.toString();
@@ -94,7 +102,10 @@ public final class PlayerPrefix implements Listener {
 
 	private static void onUpdate(Player player) throws IOException {
 		final Component component = Component.empty()
-			.append(getPrefix(player))
+			.append(
+					isUsingVanillaFormat(player) ?
+					Component.empty() : getPrefix(player)
+			)
 			.append(player.displayName());
 
 		player.playerListName(component);


### PR DESCRIPTION
I think it's a nice easter egg (as a reference to the old bug) and players may prefer the style of the vanilla chat format.

However, I'm unsure of whether the vanilla chat format should be invoked using `/prefix %` like I did in this PR, or if there should be a separate command where you can toggle the Extras chat format on or off. Perhaps both and the prefix method could still be included as an easter egg?