### PR TITLE
Respect death messages gamerule

### DIFF
--- a/src/main/java/pw/kaboom/extras/modules/player/PlayerDamage.java
+++ b/src/main/java/pw/kaboom/extras/modules/player/PlayerDamage.java
@@ -1,5 +1,6 @@
 package pw.kaboom.extras.modules.player;
 
+import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.attribute.Attribute;
@@ -51,8 +52,11 @@ public final class PlayerDamage implements Listener {
     @EventHandler
     void onPlayerDeath(final PlayerDeathEvent event) {
         final Player player = event.getEntity();
+        final Component deathMessage = event.deathMessage();
 
-        Bukkit.broadcast(event.deathMessage());
+        if (deathMessage != null) {
+            Bukkit.broadcast(deathMessage);
+        }
 
         try {
             if (!event.getKeepInventory()) {

--- a/src/main/java/pw/kaboom/extras/modules/player/PlayerDamage.java
+++ b/src/main/java/pw/kaboom/extras/modules/player/PlayerDamage.java
@@ -52,9 +52,7 @@ public final class PlayerDamage implements Listener {
     void onPlayerDeath(final PlayerDeathEvent event) {
         final Player player = event.getEntity();
 
-        for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
-            onlinePlayer.sendMessage(event.deathMessage());
-        }
+        Bukkit.broadcast(event.deathMessage());
 
         try {
             if (!event.getKeepInventory()) {


### PR DESCRIPTION
Currently, the re-implementation of player deaths in Extras doesn't respect the showDeathMessages gamerule, which is a consistent source of annoyance when players on the server are spamming commands like `/kill @e`.

I did try to implement this with an event handler for WorldLoadEvent, however it didn't seem to set the gamerule. This is probably because the plugin load order is POST_WORLD, instead of STARTUP. Unfortunately, I don't think it's possible to change this, as we register a world.

I also did some minor code clean-up besides making it respect the gamerule (deathMessage returns a nullable value so IDEs will warn about it)