### PR TITLE
Block /clone in command blocks only.

### DIFF
--- a/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
+++ b/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
@@ -76,6 +76,11 @@ public final class ServerCommand implements Listener {
             commandName = "/" + arr[1].toLowerCase();
         }
 
+        // Block /clone only in command blocks
+        if ((sender instanceof BlockCommandSender) || (sender instanceof CommandMinecart)) {
+            if (commandName == "/clone" || commandName == "/minecraft:clone") return "cancel";
+        }
+
         try {
             switch (commandName) {
                 case "/minecraft:execute", "/execute" -> {


### PR DESCRIPTION
Closes kaboomserver/server#140

The reason behind putting it here and not in the main server repo is so that I can block the clone command only in command blocks - let normal people use it anyways.