### PR TITLE
Block give in execute

### DIFF
--- a/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
+++ b/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
@@ -26,7 +26,7 @@ public final class ServerCommand implements Listener {
     private static final String[] COMMANDS = { "execute", "clone", "fill", "forceload", "kick",
             "locate", "locatebiome", "me", "msg", "reload", "save-all", "say", "spreadplayers",
             "stop", "summon", "teammsg", "teleport", "tell", "tellraw", "tm", "tp", "w", "place",
-            "fillbiome", "ride" , "tick", "jfr"};
+            "fillbiome", "ride" , "tick", "jfr", "give" };
 
     public static boolean checkExecuteCommand(final String cmd) {
         for (String command : COMMANDS) {


### PR DESCRIPTION
Closes kaboomserver/server#139

Even though there is an entity limit, which prevents extra items from spawning, this command can still lag the server when spammed.