### PR TITLE
Don't re-apply command rate-limit when command is ratelimited

### DIFF
--- a/src/main/java/pw/kaboom/extras/modules/player/PlayerChat.java
+++ b/src/main/java/pw/kaboom/extras/modules/player/PlayerChat.java
@@ -23,7 +23,7 @@ import java.util.regex.Pattern;
 public final class PlayerChat implements Listener {
     private static final PlayerChatRenderer CHAT_RENDERER = new PlayerChatRenderer();
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
     void onAsyncChatEventProcess(final AsyncChatEvent event) {
         final UUID playerUuid = event.getPlayer().getUniqueId();
 
@@ -33,6 +33,7 @@ public final class PlayerChat implements Listener {
 
             if (millisDifference < 50) {
                 event.setCancelled(true);
+                return;
             }
         }
 

--- a/src/main/java/pw/kaboom/extras/modules/player/PlayerChat.java
+++ b/src/main/java/pw/kaboom/extras/modules/player/PlayerChat.java
@@ -23,7 +23,7 @@ import java.util.regex.Pattern;
 public final class PlayerChat implements Listener {
     private static final PlayerChatRenderer CHAT_RENDERER = new PlayerChatRenderer();
 
-    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOW)
     void onAsyncChatEventProcess(final AsyncChatEvent event) {
         final UUID playerUuid = event.getPlayer().getUniqueId();
 

--- a/src/main/java/pw/kaboom/extras/modules/player/PlayerCommand.java
+++ b/src/main/java/pw/kaboom/extras/modules/player/PlayerCommand.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import io.papermc.paper.event.player.PlayerSignCommandPreprocessEvent;
 import org.bukkit.command.CommandSender;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 
@@ -14,7 +15,7 @@ import pw.kaboom.extras.modules.server.ServerCommand;
 public final class PlayerCommand implements Listener {
     private static HashMap<UUID, Long> commandMillisList = new HashMap<UUID, Long>();
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
     void onPlayerCommandPreprocess(final PlayerCommandPreprocessEvent event) {
         final UUID playerUuid = event.getPlayer().getUniqueId();
 
@@ -24,14 +25,11 @@ public final class PlayerCommand implements Listener {
 
             if (millisDifference < 75) {
                 event.setCancelled(true);
+                return;
             }
         }
 
         getCommandMillisList().put(playerUuid, System.currentTimeMillis());
-
-        if (event.isCancelled()) {
-            return;
-        }
 
         final CommandSender sender = event.getPlayer();
         final String command = event.getMessage();

--- a/src/main/java/pw/kaboom/extras/modules/player/PlayerCommand.java
+++ b/src/main/java/pw/kaboom/extras/modules/player/PlayerCommand.java
@@ -15,7 +15,7 @@ import pw.kaboom.extras.modules.server.ServerCommand;
 public final class PlayerCommand implements Listener {
     private static HashMap<UUID, Long> commandMillisList = new HashMap<UUID, Long>();
 
-    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOW)
     void onPlayerCommandPreprocess(final PlayerCommandPreprocessEvent event) {
         final UUID playerUuid = event.getPlayer().getUniqueId();
 


### PR DESCRIPTION
People are abusing this by spamming `sudo * c:///` in command blocks. Since the command rate-limit is much higher than the rate you can spam commands in command blocks, it makes it pretty much impossible to chat/run commands.

This PR tries to fix that by only rate-limiting the player after the command was allowed to run, instead of always rate-limiting the player. This should create a small gap where players are allowed to run commands, even if someone is spamming sudo commands. 