### PR TITLE
Block spawnpoint in execute

### DIFF
--- a/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
+++ b/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
@@ -25,8 +25,9 @@ public final class ServerCommand implements Listener {
 
     private static final String[] COMMANDS = { "execute", "clone", "datapack", "fill",
             "forceload", "give", "kick", "locate", "locatebiome", "me", "msg", "reload",
-            "save-all", "say", "spreadplayers", "stop", "summon", "teammsg", "teleport",
-            "tell", "tellraw", "tm", "tp", "w", "place", "fillbiome", "ride" , "tick", "jfr"};
+            "save-all", "say", "spawnpoint", "spreadplayers", "stop", "summon", "teammsg",
+            "teleport", "tell", "tellraw", "tm", "tp", "w", "place", "fillbiome", "ride" ,
+            "tick", "jfr"};
 
     public static boolean checkExecuteCommand(final String cmd) {
         for (String command : COMMANDS) {


### PR DESCRIPTION
When using `/execute` to set the world spawn point, it is possible to set a spawn point that is out of bounds. When this happens, any player dying and respawning will cause the server to immediately crash.

For example: `/execute positioned 2147483647 100 2147483647 run spawnpoint`