### PR TITLE
Use maxCommandForkCount gamerule for limiting execute

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.19.4-R0.1-SNAPSHOT</version>
+            <version>1.20.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/pw/kaboom/extras/modules/entity/EntitySpawn.java
+++ b/src/main/java/pw/kaboom/extras/modules/entity/EntitySpawn.java
@@ -37,7 +37,7 @@ public final class EntitySpawn implements Listener {
     private static final FileConfiguration CONFIG = JavaPlugin.getPlugin(Main.class).getConfig();
 
     private static final int MAX_ENTITIES_PER_CHUNK = CONFIG.getInt("maxEntitiesPerChunk");
-    private static final int MAX_ENTITIES_PER_WORLD = CONFIG.getInt("maxEntitiesPerWorld");
+    public static final int MAX_ENTITIES_PER_WORLD = CONFIG.getInt("maxEntitiesPerWorld");
     private static final int MAX_TNTS_PER_WORLD = CONFIG.getInt("maxTntsPerWorld");
 
     private void applyEntityChanges(final Entity entity) {

--- a/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
+++ b/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
@@ -18,15 +18,13 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public final class ServerCommand implements Listener {
-    private static final Pattern AS_AT_PATTERN = Pattern.compile(
-        "\\b(as|at|facing entity) @[ae]\\b");
     private static final Pattern SELECTOR_PATTERN = Pattern.compile("(?>\\s)*@[aepsr](?>\\s)*");
     private static final Logger LOGGER = JavaPlugin.getPlugin(Main.class).getLogger();
 
-    private static final String[] COMMANDS = { "execute", "clone", "datapack", "fill",
-            "forceload", "give", "kick", "locate", "locatebiome", "me", "msg", "reload",
-            "save-all", "say", "spawnpoint", "spreadplayers", "stop", "summon", "teammsg",
-            "teleport", "tell", "tellraw", "tm", "tp", "w", "place", "fillbiome", "ride" ,
+    private static final String[] COMMANDS = {"clone", "datapack", "fill", "forceload",
+            "give", "kick", "locate", "locatebiome", "me", "msg", "reload", "save-all",
+            "say", "spawnpoint", "spreadplayers", "stop", "summon", "teammsg",
+            "teleport", "tell", "tellraw", "tm", "tp", "w", "place", "fillbiome", "ride",
             "tick", "jfr"};
 
     public static boolean checkExecuteCommand(final String cmd) {
@@ -81,15 +79,6 @@ public final class ServerCommand implements Listener {
             switch (commandName) {
                 case "/minecraft:execute", "/execute" -> {
                     if (arr.length >= 2) {
-                        int asAtCount = 0;
-                        Matcher asAtMatcher = AS_AT_PATTERN.matcher(command.toLowerCase());
-                        while (asAtMatcher.find()) {
-                            asAtCount++;
-                        }
-                        if (asAtCount >= 2) {
-                            return "cancel";
-                        }
-
                         for (int i = 1; i < arr.length; i++) {
                             if ("summon".equalsIgnoreCase(arr[i])) {
                                 return "cancel";

--- a/src/main/java/pw/kaboom/extras/modules/server/ServerGameRule.java
+++ b/src/main/java/pw/kaboom/extras/modules/server/ServerGameRule.java
@@ -8,31 +8,59 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.scheduler.BukkitScheduler;
 import pw.kaboom.extras.Main;
+import pw.kaboom.extras.modules.entity.EntitySpawn;
+
+import java.util.Map;
 
 public final class ServerGameRule implements Listener {
+    private static final Map<GameRule<Integer>, Integer> GAMERULE_LIMITS = Map.of(
+            GameRule.RANDOM_TICK_SPEED, 6,
+            GameRule.SPAWN_RADIUS, 100,
+            GameRule.COMMAND_MODIFICATION_BLOCK_LIMIT, 32768,
+            GameRule.MAX_COMMAND_FORK_COUNT, EntitySpawn.MAX_ENTITIES_PER_WORLD
+    );
+
     @EventHandler
     void onGameRuleChange(final WorldGameRuleChangeEvent event) {
         final GameRule<?> gameRule = event.getGameRule();
 
-        if ((gameRule == GameRule.RANDOM_TICK_SPEED
-                && Integer.parseInt(event.getValue()) > 6)
-            || (event.getGameRule() == GameRule.SPAWN_RADIUS
-                && Integer.parseInt(event.getValue()) > 100)
-            || (event.getGameRule() == GameRule.COMMAND_MODIFICATION_BLOCK_LIMIT
-                && Integer.parseInt(event.getValue()) > 32768)) {
-            event.setCancelled(true);
+        final Integer limit = GAMERULE_LIMITS.get(gameRule);
+        if (limit == null) {
+            return;
+        }
+
+        final int value = Integer.parseInt(event.getValue());
+        if (value > limit) {
+            event.setValue(limit.toString());
         }
     }
 
     private static void enableAutoSave() {
-        for (final World world: Bukkit.getWorlds()) {
+        for (final World world : Bukkit.getWorlds()) {
             world.setAutoSave(true);
+        }
+    }
+
+    private static void fixGameRules() {
+        for (final World world : Bukkit.getWorlds()) {
+            for (final var entry : GAMERULE_LIMITS.entrySet()) {
+                final GameRule<Integer> gameRule = entry.getKey();
+                final int limit = entry.getValue();
+
+                final Integer value = world.getGameRuleValue(gameRule) != null
+                        ? world.getGameRuleValue(gameRule) : world.getGameRuleDefault(gameRule);
+
+                if (value == null || value > limit) {
+                    world.setGameRule(gameRule, limit);
+                }
+            }
         }
     }
 
     public static void init(final Main main) {
         final BukkitScheduler scheduler = Bukkit.getScheduler();
 
+        scheduler.runTask(main, ServerGameRule::fixGameRules); // Right before server fully starts
         scheduler.runTaskTimer(main, ServerGameRule::enableAutoSave, 0L, 600L); // 30 seconds
     }
 }


### PR DESCRIPTION
This PR replaces the execute as/at limiter with the maxCommandForkCount gamerule (introduced in 1.20.3), which does the same thing the execute limiter intended to do.
The limit for the gamerule is the same as the config's maxEntitiesPerWorld, which is the 
theoretical limit for the old limiter (`/execute as @e ...`).

Since the maxCommandForkCount gamerule also applies to nested execute commands, I removed the block for execute-in-execute aswell.
The code for the gamerule limiter was getting a bit messy, so I refactored that. The gamerule limits are now applied to all of the worlds on startup, because Minecraft's default for maxCommandForkCount is 65535, which is way above ours.