### PR TITLE
Allow teleportation in /execute

### DIFF
--- a/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
+++ b/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
@@ -24,7 +24,7 @@ public final class ServerCommand implements Listener {
     private static final String[] COMMANDS = {"clone", "datapack", "fill", "forceload",
             "give", "kick", "locate", "locatebiome", "me", "msg", "reload", "save-all",
             "say", "spawnpoint", "spreadplayers", "stop", "summon", "teammsg",
-            "teleport", "tell", "tellraw", "tm", "tp", "w", "place", "fillbiome", "ride",
+            "tell", "tellraw", "tm", "w", "place", "fillbiome", "ride",
             "tick", "jfr"};
 
     public static boolean checkExecuteCommand(final String cmd) {


### PR DESCRIPTION
Teleportation in /execute is quite useful for many command creations, and as such should be enabled. Most slimar methods only result in server lags or crashes.
Now I know this could be used to lag the servers, but I was not able to reproduce big lags even on a bad server running on an Android phone.