### PR TITLE
Fix NPE in spidey block iterator material checking

### DIFF
--- a/src/main/java/pw/kaboom/extras/commands/CommandSpidey.java
+++ b/src/main/java/pw/kaboom/extras/commands/CommandSpidey.java
@@ -38,10 +38,10 @@ public final class CommandSpidey implements CommandExecutor {
             distance
         );
 
-        Block block;
-        while (blockIterator.hasNext()
-                && (Material.AIR.equals((block = blockIterator.next()).getType())
-                || Material.CAVE_AIR.equals(block.getType()))) {
+        while (blockIterator.hasNext()) {
+            final Block block = blockIterator.next();
+
+            if (!block.getType().isAir()) break;
             block.setType(Material.COBWEB);
         }
         return true;

--- a/src/main/java/pw/kaboom/extras/commands/CommandSpidey.java
+++ b/src/main/java/pw/kaboom/extras/commands/CommandSpidey.java
@@ -41,7 +41,7 @@ public final class CommandSpidey implements CommandExecutor {
         while (blockIterator.hasNext()) {
             final Block block = blockIterator.next();
 
-            if (!block.getType().isAir()) break;
+            if (block.getType() != Material.COBWEB && !block.getType().isAir()) break;
             block.setType(Material.COBWEB);
         }
         return true;

--- a/src/main/java/pw/kaboom/extras/commands/CommandSpidey.java
+++ b/src/main/java/pw/kaboom/extras/commands/CommandSpidey.java
@@ -3,6 +3,7 @@ package pw.kaboom.extras.commands;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.block.Block;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -37,10 +38,11 @@ public final class CommandSpidey implements CommandExecutor {
             distance
         );
 
+        Block block;
         while (blockIterator.hasNext()
-                && (Material.AIR.equals(blockIterator.next().getType())
-                || Material.CAVE_AIR.equals(blockIterator.next().getType()))) {
-            blockIterator.next().setType(Material.COBWEB);
+                && (Material.AIR.equals((block = blockIterator.next()).getType())
+                || Material.CAVE_AIR.equals(block.getType()))) {
+            block.setType(Material.COBWEB);
         }
         return true;
     }


### PR DESCRIPTION
Each call of `next()` to a Java Iterator will cause the iterator to iterate forwards, so this would cause the previous code to iterate forwards *3* times instead of the one iteration we actually checked if it's safe to do.

This would cause an NPE when the end of the block iterator was reached. It also caused the spider web to look ugly since a lot of blocks were missed due to the erroneous iterator iteration.