### PR TITLE
Re-add CPU model detection and add GPU model detection via OSHI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,14 @@
             <version>1.20.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.github.oshi</groupId>
+            <artifactId>oshi-core</artifactId>
+            <version>6.4.5</version>
+            <!-- This is a vanilla dependency, as of 1.20.4 -->
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/java/pw/kaboom/extras/util/Utility.java
+++ b/src/main/java/pw/kaboom/extras/util/Utility.java
@@ -7,6 +7,8 @@ import org.bukkit.entity.Player;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.concurrent.Callable;
+import java.util.function.Function;
 
 public final class Utility {
     public static @Nullable Player getPlayerExactIgnoreCase(final String username) {
@@ -35,5 +37,16 @@ public final class Utility {
             }
         }
         return new String(b);
+    }
+
+    public static <T, R> @Nullable R composeCallable(
+            Callable<T> callable,
+            Function<T, R> composer
+    ) {
+        try {
+            return composer.apply(callable.call());
+        } catch (Exception e) {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
I found a way to do it without shell commands :)

...but it does depend on vanilla keeping OSHI around as a dependency, which I'm not sure about, but that's fine. I enjoy seeing the hardware information of Kaboom clones.