### PR TITLE
Allow players to send messages to each other over plugin channels

### DIFF
--- a/src/main/java/pw/kaboom/extras/Main.java
+++ b/src/main/java/pw/kaboom/extras/Main.java
@@ -2,10 +2,10 @@ package pw.kaboom.extras;
 
 import org.bukkit.WorldCreator;
 import org.bukkit.WorldType;
-import org.bukkit.block.BlockFace;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.plugin.messaging.Messenger;
 import pw.kaboom.extras.commands.*;
 import pw.kaboom.extras.modules.block.BlockCheck;
 import pw.kaboom.extras.modules.block.BlockPhysics;
@@ -18,7 +18,6 @@ import pw.kaboom.extras.modules.server.ServerGameRule;
 import pw.kaboom.extras.modules.server.ServerTabComplete;
 
 import java.io.File;
-import java.util.Collections;
 
 public final class Main extends JavaPlugin {
     private File prefixConfigFile;
@@ -91,6 +90,15 @@ public final class Main extends JavaPlugin {
         this.getServer().createWorld(
             new WorldCreator("world_flatlands").generateStructures(false).type(WorldType.FLAT)
         );
+
+        final Messenger messenger = this.getServer().getMessenger();
+        final PlayerMessaging playerMessaging = new PlayerMessaging(this);
+
+        messenger.registerIncomingPluginChannel(this, PlayerMessaging.REGISTER, playerMessaging);
+        messenger.registerIncomingPluginChannel(this, PlayerMessaging.UNREGISTER, playerMessaging);
+
+        messenger.registerIncomingPluginChannel(this, PlayerMessaging.MESSAGE, playerMessaging);
+        messenger.registerOutgoingPluginChannel(this, PlayerMessaging.MESSAGE);
     }
 
 	public File getPrefixConfigFile() {

--- a/src/main/java/pw/kaboom/extras/modules/player/PlayerMessaging.java
+++ b/src/main/java/pw/kaboom/extras/modules/player/PlayerMessaging.java
@@ -107,8 +107,9 @@ public final class PlayerMessaging implements PluginMessageListener {
         if (players == null) return;
 
         synchronized (players) {
-            // we start at null so that we do not read the bytes if the
-            // only player in the channel is the sender of the message
+            // we initialize as null so that we do not read the incoming
+            // data and serialize the payload if the only recipient
+            // would be the sender, who we do not send to
             byte[] msg = null;
 
             for (final Player playerInSet : players) {

--- a/src/main/java/pw/kaboom/extras/modules/player/PlayerMessaging.java
+++ b/src/main/java/pw/kaboom/extras/modules/player/PlayerMessaging.java
@@ -1,0 +1,180 @@
+package pw.kaboom.extras.modules.player;
+
+import com.google.common.primitives.Longs;
+import it.unimi.dsi.fastutil.io.FastByteArrayInputStream;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.messaging.Messenger;
+import org.bukkit.plugin.messaging.PluginMessageListener;
+import org.jetbrains.annotations.NotNull;
+import pw.kaboom.extras.Main;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public final class PlayerMessaging implements PluginMessageListener {
+    public static final String REGISTER = "extras:register";
+    public static final String UNREGISTER = "extras:unregister";
+    public static final String MESSAGE = "extras:message";
+
+    private static final Component ERROR =
+            Component.text("Could not send plugin channel message.", NamedTextColor.RED);
+    private static final ScheduledExecutorService SCHEDULED_EXECUTOR_SERVICE =
+            Executors.newSingleThreadScheduledExecutor();
+
+    private final Main plugin;
+
+    public PlayerMessaging(Main plugin) {
+        this.plugin = plugin;
+
+        SCHEDULED_EXECUTOR_SERVICE.scheduleAtFixedRate(() -> {
+            synchronized (this.listening) {
+                final Iterator<Map.Entry<String, Set<Player>>> iterator =
+                        this.listening.entrySet().iterator();
+
+                while (iterator.hasNext()) {
+                    final Map.Entry<String, Set<Player>> entry = iterator.next();
+
+                    final Set<Player> players = entry.getValue();
+                    synchronized (players) {
+                        // try and avoid issues with other plugins causing player obj leaks
+                        int onlineCount = 0;
+
+                        for (final Player player: players) {
+                            if (!player.isOnline()) continue;
+                            onlineCount++;
+                        }
+
+                        if (onlineCount != 0) continue;
+                        iterator.remove();
+                    }
+                }
+            }
+        }, 1, 1, TimeUnit.MINUTES);
+    }
+
+    private final Map<String, Set<Player>> listening = Collections.synchronizedMap(new HashMap<>());
+
+    private static String readString(DataInput dataInput) throws IOException {
+        final int len = dataInput.readUnsignedByte();
+        final byte[] buf = new byte[len];
+        dataInput.readFully(buf);
+        return new String(buf, StandardCharsets.US_ASCII);
+    }
+
+    private void handleRegister(final Player player, final DataInput input) throws IOException {
+        this.listening.compute(readString(input), (k, v) -> {
+            v = v == null ?
+                            Collections.synchronizedSet(
+                                    Collections.newSetFromMap(
+                                            new WeakHashMap<>()
+                                    )
+                            )
+                            :
+                            v;
+            v.add(player);
+            return v;
+        });
+    }
+
+    private void handleUnregister(final Player player, final DataInput input) throws IOException {
+        this.listening.computeIfPresent(readString(input), (k, v) -> {
+            v.remove(player);
+            return v;
+        });
+    }
+
+    private void handleMessage(final Player player,
+                               final DataInputStream input)
+            throws IOException {
+        final String channelName = readString(input);
+        final Set<Player> players = this.listening.get(channelName);
+        if (players == null) return;
+
+        synchronized (players) {
+            // we start at null so that we do not read the bytes if the
+            // only player in the channel is the sender of the message
+            byte[] msg = null;
+
+            for (final Player playerInSet : players) {
+                if (playerInSet == player) continue;
+                if (msg == null) {
+                    final int remaining = input.available();
+
+                    // remaining count + channel name + channel length header + uuid
+                    // note: calls to channelName.length() are safe because we only read ASCII
+                    final int realLength = remaining + channelName.length() + 17;
+                    if (realLength > Messenger.MAX_MESSAGE_SIZE) {
+                        player.sendMessage(ERROR);
+                        return;
+                    }
+
+                    msg = new byte[realLength];
+                    msg[0] = (byte) channelName.length();
+                    int offset = 1;
+
+                    System.arraycopy(
+                            channelName.getBytes(StandardCharsets.US_ASCII),
+                            0,
+                            msg,
+                            offset,
+                            channelName.length()
+                    );
+                    offset += channelName.length();
+
+                    final UUID uuid = player.getUniqueId();
+                    System.arraycopy(
+                            Longs.toByteArray(uuid.getMostSignificantBits()),
+                            0,
+                            msg,
+                            offset,
+                            8)
+                    ;
+                    offset += 8;
+
+                    System.arraycopy(
+                            Longs.toByteArray(uuid.getLeastSignificantBits()),
+                            0,
+                            msg,
+                            offset,
+                            8
+                    );
+                    offset += 8;
+
+                    input.readFully(msg, offset, remaining);
+                }
+
+                playerInSet.sendPluginMessage(this.plugin, MESSAGE, msg);
+            }
+        }
+    }
+
+    @Override
+    public void onPluginMessageReceived(final @NotNull String channelName,
+                                        final @NotNull Player player,
+                                        final byte[] bytes) {
+        try {
+            switch (channelName) {
+                case REGISTER -> handleRegister(
+                        player,
+                        new DataInputStream(new FastByteArrayInputStream(bytes))
+                );
+                case UNREGISTER -> handleUnregister(
+                        player,
+                        new DataInputStream(new FastByteArrayInputStream(bytes))
+                );
+                case MESSAGE -> handleMessage(
+                        player,
+                        new DataInputStream(new FastByteArrayInputStream(bytes))
+                );
+            }
+        } catch (Exception ignored) {
+            player.sendMessage(ERROR);
+        }
+    }
+}

--- a/src/main/java/pw/kaboom/extras/modules/player/PlayerMessaging.java
+++ b/src/main/java/pw/kaboom/extras/modules/player/PlayerMessaging.java
@@ -74,7 +74,7 @@ public final class PlayerMessaging implements PluginMessageListener {
             if (isLast) break;
         }
 
-        return new String(Arrays.copyOf(buf, idx), StandardCharsets.US_ASCII);
+        return new String(buf, 0, idx, StandardCharsets.US_ASCII);
     }
 
     private void handleRegister(final Player player, final DataInput input) throws IOException {

--- a/src/main/java/pw/kaboom/extras/modules/player/PlayerMessaging.java
+++ b/src/main/java/pw/kaboom/extras/modules/player/PlayerMessaging.java
@@ -30,7 +30,7 @@ public final class PlayerMessaging implements PluginMessageListener {
 
     private final Main plugin;
 
-    public PlayerMessaging(Main plugin) {
+    public PlayerMessaging(final Main plugin) {
         this.plugin = plugin;
 
         SCHEDULED_EXECUTOR_SERVICE.scheduleAtFixedRate(() -> {
@@ -61,7 +61,7 @@ public final class PlayerMessaging implements PluginMessageListener {
 
     private final Map<String, Set<Player>> listening = Collections.synchronizedMap(new HashMap<>());
 
-    private static String readString(DataInput dataInput) throws IOException {
+    private static String readString(final DataInput dataInput) throws IOException {
         final byte[] buf = new byte[255];
         int idx = 0;
 
@@ -92,7 +92,8 @@ public final class PlayerMessaging implements PluginMessageListener {
         });
     }
 
-    private void handleUnregister(final Player player, final DataInput input) throws IOException {
+    private void handleUnregister(final Player player,
+                                  final DataInput input) throws IOException {
         this.listening.computeIfPresent(readString(input), (k, v) -> {
             v.remove(player);
             return v;
@@ -185,7 +186,7 @@ public final class PlayerMessaging implements PluginMessageListener {
                         new DataInputStream(new FastByteArrayInputStream(bytes))
                 );
             }
-        } catch (Exception ignored) {
+        } catch (final Exception ignored) {
             player.sendMessage(ERROR);
         }
     }


### PR DESCRIPTION
# Background

Currently, the only way to send arbitrary data between players on Kaboom is either over chat (can get spammy, pretty inefficient due to the character limit and susceptible to mutes), over item NBT (requires players to be within each other's render distance and annoying structure parsing) or trying to stuff the data into the fields of another packet. If your client also maintains a core, you could achieve better player to player communication with tellraw - but this requires OP and maintaining a core which I do not like.

# Possible uses

- Efficiently serializing bot commands
- Implementing plugins like Simple Voice Chat without the server needing it installed
- Implementing modded logic using a bot as the "central server"
- ...and more! The only limit is your imagination and needing to fit the payload within 32766 bytes.

# Specification

## Data types

All data types are Big Endian (Network Order, largest bit first).

### String (..)

An ASCII string, with the MSB of the last byte set to 1 to denote the end of the string. Minimum length of 1 character and maximum length of 255 character. Since this is ASCII, one character == one byte.

### UUID (16)

A UUID encoded most sig bits first and least sig bits last (i.e. Big Endian).

## Registered channels

### extras:register (C->S)

|Name|Type|Description|
|-|-|-|
|Channel Name|String|The channel you would like to start receiving `extras:message`s for.|

### extras:unregister (C->S)

|Name|Type|Description|
|-|-|-|
|Channel Name|String|The channel you would like to stop receiving `extras:message`s from.|

### extras:message (C->S, S->C)

You don't need to be registered to a channel to send this (but you need to be registered to a channel to receive messages from that channel), and the plugin will not send any `extras:message` packets with data originating from you back to you. However, if an error occurs, the plugin will send you a message in chat telling you that it failed, with no additional error information.

|Name|Type|Description|
|-|-|-|
|Channel Name|String|The channel from which this message originates from.|
|Source UUID|UUID (not sent by client)|The player from which this message originates from.|
|Message|Channel Detail|The message that the player sent. This can be anything, and is not length prefixed.|

## Notes

- In order to receive `extras:message` from the server, you **MUST** send `minecraft:register` with the channel name. Please note that the standard for that custom payload packet is actually a list of channel names to register delimited by a null byte (`0x00`, `\0`). However, to send any of the aforementioned channels, you don't need to register the channel first - but this may change in future Paper versions. (NOTE: you must also send `extras:register` too.)
- Messages are sent to everyone registered to a channel as implementing an ownership and message routing system could be tricky, and would decrease efficiency.
- As the list of channel names is only known to the server and any clients registering to it, multiple clients could create a scheme to agree upon private channel names using an asymmetric encryption algorithm and pre-shared key/key-agreement algorithm. However, no protections are implemented against side-channel attacks aiming to discover registered channel names by collecting the time it takes to process `extras:register` or `extras:message` for a specific channel name, so you should not rely upon a secret channel name for confidentiality and should instead look towards implementing encryption.
- I have not implemented any restrictions on the contents, amount of players registered or amount of channels registered because I'm not sure how I could limit that well without decreasing the usefulness of this addition.
- Further improvements could be made to the amount of data available in the message portion of `extras:message` by directly registering the channel name in the Messenger, entirely removing the channel name field in `extras:message` (and `extras:message` itself). However, this might lead to conflicts with other plugins and we would need to register the channel with Bukkit Messenger, likely leading to performance loss. The server is also likely to resend minecraft:register, which could cause issues with lots of channels registered. It should be possible to also make a size improvement by removing `extras:register` and `extras:unregister`, and just registering the player for all `extras:` channels it `minecraft:register`s too, with the same pitfalls aforementioned.