### PR TITLE
Don't use block state snapshot in ServerCommandEvent

### DIFF
--- a/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
+++ b/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
@@ -180,10 +180,9 @@ public final class ServerCommand implements Listener {
         final CommandSender sender = event.getSender();
 
         if (sender instanceof BlockCommandSender blockCommandSender) {
-            final var commandBlock = (CommandBlock) blockCommandSender.getBlock().getState();
+            final var commandBlock = (CommandBlock) blockCommandSender.getBlock().getState(false);
 
             commandBlock.setCommand("");
-            commandBlock.update();
         } else if (sender instanceof CommandMinecart commandMinecart) {
             commandMinecart.setCommand("");
         }


### PR DESCRIPTION
This avoids copying the command block NBT data, meaning it should reduce memory consumption and increase performance by a few microseconds when commands are run through command blocks.

The update call is not necessary as we operate directly on the block data when useSnapshot is false.