### PR TITLE
Fix: limit selectors in /me

### DIFF
--- a/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
+++ b/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
@@ -133,7 +133,8 @@ public final class ServerCommand implements Listener {
                 }
                 case "/minecraft:ban", "/ban", "/minecraft:kick", "/kick",
                         "/minecraft:tell", "/tell", "/minecraft:msg", "/msg",
-                        "/minecraft:w", "/w", "/minecraft:say", "/say" -> {
+                        "/minecraft:w", "/w", "/minecraft:say", "/say", "/minecraft:me",
+                        "/me" -> {
                     return checkSelectors(arr, 1);
                 }
                 case "/minecraft:spreadplayers", "/spreadplayers" -> {


### PR DESCRIPTION
This fixes a lag / crash method where spamming /me @e@e@e@e would result in huge lag and server crashes