### PR TITLE
Fix behavior when OSHI can't run

### DIFF
--- a/src/main/java/pw/kaboom/extras/commands/CommandServerInfo.java
+++ b/src/main/java/pw/kaboom/extras/commands/CommandServerInfo.java
@@ -17,7 +17,7 @@ import java.lang.management.ManagementFactory;
 import java.net.InetAddress;
 
 public final class CommandServerInfo implements CommandExecutor {
-    private static final @Nullable String[] GPU_DEVICES;
+    private static final String[] GPU_DEVICES;
     private static final @Nullable String PROCESSOR_NAME;
 
     static {
@@ -48,7 +48,7 @@ public final class CommandServerInfo implements CommandExecutor {
         );
 
         if (hardwareInfo == null) {
-            GPU_DEVICES = null;
+            GPU_DEVICES = new String[0];
             PROCESSOR_NAME = null;
         } else {
             GPU_DEVICES = hardwareInfo.first();
@@ -95,7 +95,9 @@ public final class CommandServerInfo implements CommandExecutor {
                     + ManagementFactory.getRuntimeMXBean().getVmVersion()
         );
 
-        sendInfoMessage(sender, "CPU model", PROCESSOR_NAME);
+        if (PROCESSOR_NAME != null) {
+            sendInfoMessage(sender, "CPU model", PROCESSOR_NAME);
+        }
 
         sendInfoMessage(sender, "CPU cores",
             String.valueOf(Runtime.getRuntime().availableProcessors())

--- a/src/main/java/pw/kaboom/extras/util/Utility.java
+++ b/src/main/java/pw/kaboom/extras/util/Utility.java
@@ -45,7 +45,7 @@ public final class Utility {
     ) {
         try {
             return composer.apply(callable.call());
-        } catch (Exception e) {
+        } catch (Throwable ex) {
             return null;
         }
     }


### PR DESCRIPTION
Looks like we need to catch `Error`s, and not just regular `Exception`s, when running Extras in environments like Termux.

Also fixes my code assuming GPU_DEVICES and PROCESSOR_NAME always load correctly (oops!)