### PR TITLE
Code cleanups

### DIFF
--- a/src/main/java/pw/kaboom/extras/modules/player/PlayerChat.java
+++ b/src/main/java/pw/kaboom/extras/modules/player/PlayerChat.java
@@ -98,11 +98,6 @@ public final class PlayerChat implements Listener {
                                          @Nonnull Component displayName,
                                          @Nonnull Component component,
                                          @Nonnull Audience audience) {
-            if (PlayerPrefix.isUsingVanillaFormat(player)) {
-                return renderVanilla(displayName, component);
-            }
-
-            Component newComponent = Component.empty();
             final Component prefix;
             Component prefix1;
 
@@ -114,9 +109,12 @@ public final class PlayerChat implements Listener {
             }
 
             prefix = prefix1;
-            final String message = ((TextComponent) component).content();
+            if (prefix == null) {
+                return renderVanilla(displayName, component);
+            }
 
-            newComponent = newComponent
+            final String message = ((TextComponent) component).content();
+            final Component newComponent = Component.empty()
                     .append(prefix)
                     .append(displayName)
                     .append(Component.text(":"))

--- a/src/main/java/pw/kaboom/extras/modules/player/PlayerChat.java
+++ b/src/main/java/pw/kaboom/extras/modules/player/PlayerChat.java
@@ -42,10 +42,10 @@ public final class PlayerChat implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     void onAsyncChatEventRenderer(final AsyncChatEvent event) {
-        event.renderer(CHAT_RENDERER);
+        event.renderer(ChatRenderer.viewerUnaware(CHAT_RENDERER));
     }
 
-    public static class PlayerChatRenderer implements ChatRenderer {
+    public static class PlayerChatRenderer implements ChatRenderer.ViewerUnaware {
         private static final TextReplacementConfig URL_REPLACEMENT_CONFIG =
                 TextReplacementConfig
                         .builder()
@@ -96,8 +96,7 @@ public final class PlayerChat implements Listener {
         @Override
         public @Nonnull Component render(@Nonnull Player player,
                                          @Nonnull Component displayName,
-                                         @Nonnull Component component,
-                                         @Nonnull Audience audience) {
+                                         @Nonnull Component component) {
             final Component prefix;
             Component prefix1;
 

--- a/src/main/java/pw/kaboom/extras/modules/player/PlayerDamage.java
+++ b/src/main/java/pw/kaboom/extras/modules/player/PlayerDamage.java
@@ -53,7 +53,7 @@ public final class PlayerDamage implements Listener {
         final AttributeInstance attribute = player.getAttribute(Attribute.MAX_HEALTH);
         if (attribute == null) return;
         if (attribute.getValue() <= 0) {
-            Utility.resetAttribute(attribute);
+            Utility.resetAttribute(player, Attribute.MAX_HEALTH);
             player.setHealth(20);
         }
     }
@@ -97,11 +97,7 @@ public final class PlayerDamage implements Listener {
                 xp.setExperience(event.getDroppedExp());
             }
 
-            final AttributeInstance attribute = player.getAttribute(Attribute.MAX_HEALTH);
-            if (attribute != null) {
-                Utility.resetAttribute(attribute);
-            }
-
+            Utility.resetAttribute(player, Attribute.MAX_HEALTH);
             player.setHealth(20);
 
             if (player.getRespawnLocation() != null) {
@@ -111,10 +107,7 @@ public final class PlayerDamage implements Listener {
                 player.teleportAsync(world.getSpawnLocation());
             }
         } catch (Exception exception) {
-            final AttributeInstance attribute = player.getAttribute(Attribute.MAX_HEALTH);
-            if (attribute != null) {
-                Utility.resetAttribute(attribute);
-            }
+            Utility.resetAttribute(player, Attribute.MAX_HEALTH);
             player.setHealth(20);
         }
 

--- a/src/main/java/pw/kaboom/extras/modules/player/PlayerTeleport.java
+++ b/src/main/java/pw/kaboom/extras/modules/player/PlayerTeleport.java
@@ -16,7 +16,7 @@ public final class PlayerTeleport implements Listener {
         final AttributeInstance attribute = player.getAttribute(Attribute.MAX_HEALTH);
         if (attribute == null) return;
         if (attribute.getValue() <= 0) {
-            Utility.resetAttribute(attribute);
+            Utility.resetAttribute(player, Attribute.MAX_HEALTH);
             player.setHealth(20);
         }
     }

--- a/src/main/java/pw/kaboom/extras/util/Utility.java
+++ b/src/main/java/pw/kaboom/extras/util/Utility.java
@@ -1,8 +1,11 @@
 package pw.kaboom.extras.util;
 
 import org.bukkit.Bukkit;
+import org.bukkit.attribute.Attributable;
+import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.attribute.AttributeModifier;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 
 import javax.annotation.Nonnull;
@@ -19,12 +22,22 @@ public final class Utility {
                 .orElse(null);
     }
 
-    public static void resetAttribute(final AttributeInstance attribute) {
-        for (final AttributeModifier modifier: attribute.getModifiers()) {
-            attribute.removeModifier(modifier);
+    public static <T extends Entity & Attributable> void resetAttribute (final T entity,
+                                                                         final Attribute attrib) {
+        final AttributeInstance instance = entity.getAttribute(attrib);
+        if (instance == null) return;
+
+        for (final AttributeModifier modifier : instance.getModifiers()) {
+            instance.removeModifier(modifier);
         }
 
-        attribute.setBaseValue(attribute.getDefaultValue());
+        final AttributeInstance defaultInstance = entity.getType().getDefaultAttributes()
+                .getAttribute(instance.getAttribute());
+        if (defaultInstance != null) {
+            instance.setBaseValue(defaultInstance.getBaseValue());
+        } else {
+            instance.setBaseValue(instance.getDefaultValue());
+        }
     }
 
     // TODO: Support hex color codes, too (they aren't supported in Spigot either)


### PR DESCRIPTION
Utility#resetAttribute now accounts for entity-specific default attributes, in case it's ever needed for attributes other than MAX_HEALTH in the future.

Chat rendering no longer renders a message once per player on the server, but rather, once per message, which should help with performance when there's lots of talking players on the server (e.g.: when it gets spambotted).

The URL rendering is now done by adventure's LegacyComponentSerializer. I'm not sure why that wasn't being done previously, seeing as it was introduced in version 4.0.0 (released long before URL support was added to Extras).