### PR TITLE
fix: don't log broadcast commands to console

### DIFF
--- a/src/main/java/pw/kaboom/extras/commands/CommandBroadcastMM.java
+++ b/src/main/java/pw/kaboom/extras/commands/CommandBroadcastMM.java
@@ -7,6 +7,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 
 import javax.annotation.Nonnull;
 
@@ -23,7 +24,12 @@ public final class CommandBroadcastMM implements CommandExecutor {
             return true;
         }
 
-        Bukkit.broadcast(MINI_MESSAGE.deserialize(String.join(" ", args)));
+        final Component component = MINI_MESSAGE.deserialize(String.join(" ", args));
+
+        for (Player onlinePlayer: Bukkit.getOnlinePlayers()) {
+            onlinePlayer.sendMessage(component);
+        }
+
         return true;
     }
 }

--- a/src/main/java/pw/kaboom/extras/commands/CommandBroadcastRainbow.java
+++ b/src/main/java/pw/kaboom/extras/commands/CommandBroadcastRainbow.java
@@ -26,7 +26,11 @@ public final class CommandBroadcastRainbow implements CommandExecutor {
         }
         final String strippedTags = MINI_MESSAGE.stripTags(String.join(" ", args));
         final Component component = MINI_MESSAGE.deserialize("<rainbow>" + strippedTags);
-        Bukkit.getServer().broadcast(component);
+
+        for (Player onlinePlayer: Bukkit.getOnlinePlayers()) {
+            onlinePlayer.sendMessage(component);
+        }
+
         return true;
     }
 }


### PR DESCRIPTION
Bukkit#broadcast also logs components to console. To prevent players from spamming the logs (and also crashing the server with certain components, see https://github.com/kaboomserver/papermixins/commit/7837ded6061510686b8104b07fa025033f3e143f), we mustn't do that.