### PR TITLE
Replace control characters when logging console commands

### DIFF
--- a/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
+++ b/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
@@ -21,6 +21,7 @@ import java.util.regex.Pattern;
 
 public final class ServerCommand implements Listener {
     private static final Pattern SELECTOR_PATTERN = Pattern.compile("(?>\\s)*@[aenprs](?>\\s)*");
+    private static final Pattern CONTROL_CHAR_PATTERN = Pattern.compile("\\p{C}");
     private static final Logger LOGGER = JavaPlugin.getPlugin(Main.class).getLogger();
 
     private static final Set<String> BLOCKED_EXECUTE_COMMANDS = ImmutableSet.of(
@@ -200,6 +201,9 @@ public final class ServerCommand implements Listener {
             }
         }
 
-        LOGGER.log(Level.INFO, "Console command: " + command);
+        LOGGER.log(
+                Level.INFO,
+                "Console command: " + CONTROL_CHAR_PATTERN.matcher(command).replaceAll("\ufffd")
+        );
     }
 }


### PR DESCRIPTION
Prevents people from using ANSI escape sequences and messing up the terminal, among other undesirable sequences (i.e. RLO, newline, carriage return), without mangling emoji & non-English text.