### PR TITLE
Make everything which makes sense to be configured by the user configurable

### DIFF
--- a/src/main/java/pw/kaboom/extras/Main.java
+++ b/src/main/java/pw/kaboom/extras/Main.java
@@ -87,9 +87,10 @@ public final class Main extends JavaPlugin {
         this.getServer().getPluginManager().registerEvents(new ServerTabComplete(), this);
 
         /* Custom worlds */
-        this.getServer().createWorld(
-            new WorldCreator("world_flatlands").generateStructures(false).type(WorldType.FLAT)
-        );
+        if (this.getConfig().getBoolean("generateFlatlands"))
+            this.getServer().createWorld(
+                new WorldCreator("world_flatlands").generateStructures(false).type(WorldType.FLAT)
+            );
 
         final Messenger messenger = this.getServer().getMessenger();
         final PlayerMessaging playerMessaging = new PlayerMessaging(this);

--- a/src/main/java/pw/kaboom/extras/commands/CommandPrefix.java
+++ b/src/main/java/pw/kaboom/extras/commands/CommandPrefix.java
@@ -6,12 +6,16 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import pw.kaboom.extras.Main;
 import pw.kaboom.extras.modules.player.PlayerPrefix;
 
 import javax.annotation.Nonnull;
 
 public final class CommandPrefix implements CommandExecutor {
-    private static final int MAX_PREFIX_LENGTH = 1024;
+    private static final int MAX_PREFIX_LENGTH = JavaPlugin.getPlugin(Main.class)
+            .getConfig()
+            .getInt("maxPrefixLength");
 
     public boolean onCommand(final @Nonnull CommandSender sender,
                              final @Nonnull Command cmd,

--- a/src/main/java/pw/kaboom/extras/modules/entity/EntityExplosion.java
+++ b/src/main/java/pw/kaboom/extras/modules/entity/EntityExplosion.java
@@ -1,24 +1,29 @@
 package pw.kaboom.extras.modules.entity;
 
 import org.bukkit.World;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Fireball;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.ExplosionPrimeEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+import pw.kaboom.extras.Main;
 
 public final class EntityExplosion implements Listener {
+    private static final FileConfiguration CONFIG = JavaPlugin.getPlugin(Main.class).getConfig();
+
+    private static final int MAX_EXPLOSION_RADIUS = CONFIG.getInt("maxExplosionRadius");
+    private static final int MAX_FIREBALL_COUNT = CONFIG.getInt("maxFireballCount");
+
     @EventHandler
     void onExplosionPrime(final ExplosionPrimeEvent event) {
-        final int maxRadius = 20;
-
-        if (event.getRadius() > maxRadius) {
-            event.setRadius(maxRadius);
+        if (event.getRadius() > MAX_EXPLOSION_RADIUS) {
+            event.setRadius(MAX_EXPLOSION_RADIUS);
         }
 
         final World world = event.getEntity().getWorld();
-        final int maxFireballCount = 30;
 
-        if (world.getEntitiesByClass(Fireball.class).size() > maxFireballCount
+        if (world.getEntitiesByClass(Fireball.class).size() > MAX_FIREBALL_COUNT
                 && event.getRadius() > 1) {
             event.setRadius(1);
         }

--- a/src/main/java/pw/kaboom/extras/modules/entity/EntityKnockback.java
+++ b/src/main/java/pw/kaboom/extras/modules/entity/EntityKnockback.java
@@ -4,10 +4,15 @@ import io.papermc.paper.event.entity.EntityKnockbackEvent;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
+import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.util.Vector;
+import pw.kaboom.extras.Main;
 
 public final class EntityKnockback implements Listener {
-    private static final double KNOCKBACK_LIMIT = 20; // translates to enchantment level 40
+    // default translates to enchantment level 40
+    private static final double KNOCKBACK_LIMIT = JavaPlugin.getPlugin(Main.class)
+            .getConfig()
+            .getDouble("maxKnockbackVelocity");
     private static final double KNOCKBACK_LIMIT_SQUARED = KNOCKBACK_LIMIT * KNOCKBACK_LIMIT;
 
     @EventHandler

--- a/src/main/java/pw/kaboom/extras/modules/entity/EntitySpawn.java
+++ b/src/main/java/pw/kaboom/extras/modules/entity/EntitySpawn.java
@@ -36,6 +36,7 @@ public final class EntitySpawn implements Listener {
     private static final int MAX_TNTS_PER_WORLD = CONFIG.getInt("maxTntsPerWorld");
     private static final int MAX_DRAGONS_PER_WORLD = CONFIG.getInt("maxDragonsPerWorld");
     private static final int MAX_WITHERS_PER_WORLD = CONFIG.getInt("maxWithersPerWorld");
+    private static final int MAX_TNT_MINECARTS_PER_WORLD = CONFIG.getInt("maxTntMinecartsPerWorld");
 
     private void applyEntityChanges(final Entity entity) {
         switch (entity.getType()) {
@@ -165,7 +166,7 @@ public final class EntitySpawn implements Listener {
     void onExplosionPrime(final ExplosionPrimeEvent event) {
         if (EntityType.TNT_MINECART.equals(event.getEntityType())
                 && event.getEntity().getWorld()
-                .getEntitiesByClass(ExplosiveMinecart.class).size() > 80) {
+                .getEntitiesByClass(ExplosiveMinecart.class).size() > MAX_TNT_MINECARTS_PER_WORLD) {
             event.setCancelled(true);
         }
     }

--- a/src/main/java/pw/kaboom/extras/modules/entity/EntitySpawn.java
+++ b/src/main/java/pw/kaboom/extras/modules/entity/EntitySpawn.java
@@ -42,6 +42,7 @@ public final class EntitySpawn implements Listener {
     private static final int MAX_ENTITIES_PER_CHUNK = CONFIG.getInt("maxEntitiesPerChunk");
     public static final int MAX_ENTITIES_PER_WORLD = CONFIG.getInt("maxEntitiesPerWorld");
     private static final int MAX_TNTS_PER_WORLD = CONFIG.getInt("maxTntsPerWorld");
+    private static final int MAX_DRAGONS_PER_WORLD = CONFIG.getInt("maxDragonsPerWorld");
 
     private void applyEntityChanges(final Entity entity) {
         switch (entity.getType()) {
@@ -84,9 +85,8 @@ public final class EntitySpawn implements Listener {
         switch (entityType) {
         case ENDER_DRAGON:
             final int worldDragonCount = world.getEntitiesByClass(EnderDragon.class).size();
-            final int worldDragonCountLimit = 24;
 
-            if (worldDragonCount >= worldDragonCountLimit) {
+            if (worldDragonCount >= MAX_DRAGONS_PER_WORLD) {
                 return true;
             }
             break;

--- a/src/main/java/pw/kaboom/extras/modules/entity/EntitySpawn.java
+++ b/src/main/java/pw/kaboom/extras/modules/entity/EntitySpawn.java
@@ -9,15 +9,7 @@ import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.block.CreatureSpawner;
 import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.entity.AreaEffectCloud;
-import org.bukkit.entity.EnderDragon;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.FallingBlock;
-import org.bukkit.entity.LightningStrike;
-import org.bukkit.entity.Slime;
-import org.bukkit.entity.TNTPrimed;
-import org.bukkit.entity.Vehicle;
+import org.bukkit.entity.*;
 import org.bukkit.entity.minecart.ExplosiveMinecart;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -43,6 +35,7 @@ public final class EntitySpawn implements Listener {
     public static final int MAX_ENTITIES_PER_WORLD = CONFIG.getInt("maxEntitiesPerWorld");
     private static final int MAX_TNTS_PER_WORLD = CONFIG.getInt("maxTntsPerWorld");
     private static final int MAX_DRAGONS_PER_WORLD = CONFIG.getInt("maxDragonsPerWorld");
+    private static final int MAX_WITHERS_PER_WORLD = CONFIG.getInt("maxWithersPerWorld");
 
     private void applyEntityChanges(final Entity entity) {
         switch (entity.getType()) {
@@ -87,6 +80,13 @@ public final class EntitySpawn implements Listener {
             final int worldDragonCount = world.getEntitiesByClass(EnderDragon.class).size();
 
             if (worldDragonCount >= MAX_DRAGONS_PER_WORLD) {
+                return true;
+            }
+            break;
+        case WITHER:
+            final int worldWitherCount = world.getEntitiesByClass(Wither.class).size();
+
+            if (worldWitherCount >= MAX_WITHERS_PER_WORLD) {
                 return true;
             }
             break;

--- a/src/main/java/pw/kaboom/extras/modules/entity/EntitySpawn.java
+++ b/src/main/java/pw/kaboom/extras/modules/entity/EntitySpawn.java
@@ -49,6 +49,9 @@ public final class EntitySpawn implements Listener {
     private static final int EFFECT_CLOUD_MAX_RADIUS_PER_TICK =
             CONFIG.getInt("effectCloudMaxRadiusPerTick");
 
+    private static final int MAX_SLIME_SIZE =
+            CONFIG.getInt("maxSlimeSize");
+
     private void applyEntityChanges(final Entity entity) {
         switch (entity.getType()) {
             case AREA_EFFECT_CLOUD:
@@ -135,8 +138,8 @@ public final class EntitySpawn implements Listener {
         final AttributeInstance scaleInstance = slime.getAttribute(Attribute.SCALE);
         final double scale = scaleInstance != null ? scaleInstance.getValue() : 1.0f;
 
-        if ((slime.getSize() * scale) > 20) {
-            slime.setSize(20);
+        if ((slime.getSize() * scale) > MAX_SLIME_SIZE) {
+            slime.setSize(MAX_SLIME_SIZE);
             Utility.resetAttribute(slime, Attribute.SCALE);
         }
     }

--- a/src/main/java/pw/kaboom/extras/modules/entity/EntitySpawn.java
+++ b/src/main/java/pw/kaboom/extras/modules/entity/EntitySpawn.java
@@ -42,6 +42,12 @@ public final class EntitySpawn implements Listener {
     private static final int SPAWNER_MAX_SPAWN_COUNT = CONFIG.getInt("spawnerMaxSpawnCount");
     private static final int SPAWNER_MAX_SPAWN_RANGE = CONFIG.getInt("spawnerMaxSpawnRange");
 
+    private static final int EFFECT_CLOUD_MAX_RADIUS =
+            CONFIG.getInt("effectCloudMaxRadius");
+    private static final int EFFECT_CLOUD_MAX_RADIUS_ON_USE =
+            CONFIG.getInt("effectCloudMaxRadiusOnUse");
+    private static final int EFFECT_CLOUD_MAX_RADIUS_PER_TICK =
+            CONFIG.getInt("effectCloudMaxRadiusPerTick");
 
     private void applyEntityChanges(final Entity entity) {
         switch (entity.getType()) {
@@ -117,17 +123,12 @@ public final class EntitySpawn implements Listener {
     }
 
     private void limitAreaEffectCloudRadius(final AreaEffectCloud cloud) {
-        if (cloud.getRadius() > 40) {
-            cloud.setRadius(40);
-        }
-
-        if (cloud.getRadiusOnUse() > 0.01f) {
-            cloud.setRadiusOnUse(0.1f);
-        }
-
-        if (cloud.getRadiusPerTick() > 0) {
-            cloud.setRadiusPerTick(0);
-        }
+        cloud.setRadius(Math.min(EFFECT_CLOUD_MAX_RADIUS, cloud.getRadius()));
+        cloud.setRadiusOnUse(Math.min(EFFECT_CLOUD_MAX_RADIUS_ON_USE, cloud.getRadiusPerTick()));
+        cloud.setRadiusPerTick(Math.min(
+                EFFECT_CLOUD_MAX_RADIUS_PER_TICK,
+                cloud.getRadiusPerTick())
+        );
     }
 
     private void limitSlimeSize(final Slime slime) {

--- a/src/main/java/pw/kaboom/extras/modules/entity/EntitySpawn.java
+++ b/src/main/java/pw/kaboom/extras/modules/entity/EntitySpawn.java
@@ -38,6 +38,11 @@ public final class EntitySpawn implements Listener {
     private static final int MAX_WITHERS_PER_WORLD = CONFIG.getInt("maxWithersPerWorld");
     private static final int MAX_TNT_MINECARTS_PER_WORLD = CONFIG.getInt("maxTntMinecartsPerWorld");
 
+    private static final int SPAWNER_MIN_SPAWN_DELAY = CONFIG.getInt("spawnerMinSpawnDelay");
+    private static final int SPAWNER_MAX_SPAWN_COUNT = CONFIG.getInt("spawnerMaxSpawnCount");
+    private static final int SPAWNER_MAX_SPAWN_RANGE = CONFIG.getInt("spawnerMaxSpawnRange");
+
+
     private void applyEntityChanges(final Entity entity) {
         switch (entity.getType()) {
             case AREA_EFFECT_CLOUD:
@@ -140,21 +145,10 @@ public final class EntitySpawn implements Listener {
             spawner.setSpawnedType(EntityType.MINECART);
         }
 
-        if (spawner.getMinSpawnDelay() < 1000) {
-            spawner.setMinSpawnDelay(1000);
-        }
-
-        if (spawner.getMaxSpawnDelay() < 1000) {
-            spawner.setMaxSpawnDelay(1000);
-        }
-
-        if (spawner.getSpawnCount() > 200) {
-            spawner.setSpawnCount(200);
-        }
-
-        if (spawner.getSpawnRange() > 50) {
-            spawner.setSpawnRange(50);
-        }
+        spawner.setMinSpawnDelay(Math.max(SPAWNER_MIN_SPAWN_DELAY, spawner.getMinSpawnDelay()));
+        spawner.setMaxSpawnDelay(Math.max(SPAWNER_MIN_SPAWN_DELAY, spawner.getMaxSpawnDelay()));
+        spawner.setSpawnCount(Math.min(SPAWNER_MAX_SPAWN_COUNT, spawner.getSpawnCount()));
+        spawner.setSpawnRange(Math.min(SPAWNER_MAX_SPAWN_RANGE, spawner.getSpawnRange()));
     }
 
     @EventHandler

--- a/src/main/java/pw/kaboom/extras/modules/player/PlayerChat.java
+++ b/src/main/java/pw/kaboom/extras/modules/player/PlayerChat.java
@@ -12,6 +12,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.plugin.java.JavaPlugin;
+import pw.kaboom.extras.Main;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
@@ -20,6 +22,9 @@ import java.util.regex.Pattern;
 
 public final class PlayerChat implements Listener {
     private static final PlayerChatRenderer CHAT_RENDERER = new PlayerChatRenderer();
+    private static final long MIN_CHAT_DELAY_MILLIS = JavaPlugin.getPlugin(Main.class)
+            .getConfig()
+            .getLong("minChatDelayMillis");
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.LOW)
     void onAsyncChatEventProcess(final AsyncChatEvent event) {
@@ -29,7 +34,7 @@ public final class PlayerChat implements Listener {
             final long lastCommandTime = PlayerCommand.getLastCommandExec().get(playerUuid);
             final long millisDifference = System.currentTimeMillis() - lastCommandTime;
 
-            if (millisDifference < 50) {
+            if (millisDifference < MIN_CHAT_DELAY_MILLIS) {
                 event.setCancelled(true);
                 return;
             }

--- a/src/main/java/pw/kaboom/extras/modules/player/PlayerChat.java
+++ b/src/main/java/pw/kaboom/extras/modules/player/PlayerChat.java
@@ -25,8 +25,8 @@ public final class PlayerChat implements Listener {
     void onAsyncChatEventProcess(final AsyncChatEvent event) {
         final UUID playerUuid = event.getPlayer().getUniqueId();
 
-        if (PlayerCommand.getCommandMillisList().get(playerUuid) != null) {
-            final long lastCommandTime = PlayerCommand.getCommandMillisList().get(playerUuid);
+        if (PlayerCommand.getLastCommandExec().get(playerUuid) != null) {
+            final long lastCommandTime = PlayerCommand.getLastCommandExec().get(playerUuid);
             final long millisDifference = System.currentTimeMillis() - lastCommandTime;
 
             if (millisDifference < 50) {
@@ -35,7 +35,7 @@ public final class PlayerChat implements Listener {
             }
         }
 
-        PlayerCommand.getCommandMillisList().put(playerUuid, System.currentTimeMillis());
+        PlayerCommand.getLastCommandExec().put(playerUuid, System.currentTimeMillis());
     }
 
     @EventHandler(priority = EventPriority.MONITOR)

--- a/src/main/java/pw/kaboom/extras/modules/player/PlayerCommand.java
+++ b/src/main/java/pw/kaboom/extras/modules/player/PlayerCommand.java
@@ -1,6 +1,7 @@
 package pw.kaboom.extras.modules.player;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import io.papermc.paper.event.player.PlayerSignCommandPreprocessEvent;
@@ -15,7 +16,7 @@ import pw.kaboom.extras.Main;
 import pw.kaboom.extras.modules.server.ServerCommand;
 
 public final class PlayerCommand implements Listener {
-    private static HashMap<UUID, Long> commandMillisList = new HashMap<UUID, Long>();
+    private static final Map<UUID, Long> LAST_COMMAND_EXEC = new HashMap<>();
     private static final long MIN_COMMAND_DELAY_MILLIS = JavaPlugin.getPlugin(Main.class)
             .getConfig()
             .getLong("minCommandDelayMillis");
@@ -24,8 +25,8 @@ public final class PlayerCommand implements Listener {
     void onPlayerCommandPreprocess(final PlayerCommandPreprocessEvent event) {
         final UUID playerUuid = event.getPlayer().getUniqueId();
 
-        if (getCommandMillisList().get(playerUuid) != null) {
-            final long lastCommandTime = getCommandMillisList().get(playerUuid);
+        if (getLastCommandExec().get(playerUuid) != null) {
+            final long lastCommandTime = getLastCommandExec().get(playerUuid);
             final long millisDifference = System.currentTimeMillis() - lastCommandTime;
 
             if (millisDifference < MIN_COMMAND_DELAY_MILLIS) {
@@ -34,7 +35,7 @@ public final class PlayerCommand implements Listener {
             }
         }
 
-        getCommandMillisList().put(playerUuid, System.currentTimeMillis());
+        getLastCommandExec().put(playerUuid, System.currentTimeMillis());
 
         final CommandSender sender = event.getPlayer();
         final String command = event.getMessage();
@@ -55,7 +56,7 @@ public final class PlayerCommand implements Listener {
         this.onPlayerCommandPreprocess(event);
     }
 
-    public static HashMap<UUID, Long> getCommandMillisList() {
-        return commandMillisList;
+    public static Map<UUID, Long> getLastCommandExec() {
+        return LAST_COMMAND_EXEC;
     }
 }

--- a/src/main/java/pw/kaboom/extras/modules/player/PlayerCommand.java
+++ b/src/main/java/pw/kaboom/extras/modules/player/PlayerCommand.java
@@ -10,10 +10,15 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 
+import org.bukkit.plugin.java.JavaPlugin;
+import pw.kaboom.extras.Main;
 import pw.kaboom.extras.modules.server.ServerCommand;
 
 public final class PlayerCommand implements Listener {
     private static HashMap<UUID, Long> commandMillisList = new HashMap<UUID, Long>();
+    private static final long MIN_COMMAND_DELAY_MILLIS = JavaPlugin.getPlugin(Main.class)
+            .getConfig()
+            .getLong("minCommandDelayMillis");
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.LOW)
     void onPlayerCommandPreprocess(final PlayerCommandPreprocessEvent event) {
@@ -23,7 +28,7 @@ public final class PlayerCommand implements Listener {
             final long lastCommandTime = getCommandMillisList().get(playerUuid);
             final long millisDifference = System.currentTimeMillis() - lastCommandTime;
 
-            if (millisDifference < 75) {
+            if (millisDifference < MIN_COMMAND_DELAY_MILLIS) {
                 event.setCancelled(true);
                 return;
             }

--- a/src/main/java/pw/kaboom/extras/modules/player/PlayerConnection.java
+++ b/src/main/java/pw/kaboom/extras/modules/player/PlayerConnection.java
@@ -64,6 +64,9 @@ public final class PlayerConnection implements Listener {
     private static final boolean OP_ON_JOIN = CONFIG.getBoolean("opOnJoin");
     private static final boolean RANDOMIZE_SPAWN = CONFIG.getBoolean("randomizeSpawn");
 
+    private static final double RANDOMIZE_SPAWN_RADIUS = CONFIG.getDouble("randomizeSpawnRadius");
+    private static final double RANDOMIZE_SPAWN_Y = CONFIG.getDouble("randomizeSpawnY");
+
     private static final EnumSet<PlayerKickEvent.Cause> ALLOWED_KICK_CAUSES = EnumSet.of(
         PlayerKickEvent.Cause.TIMEOUT,  PlayerKickEvent.Cause.INVALID_VEHICLE_MOVEMENT,
         PlayerKickEvent.Cause.INVALID_PLAYER_MOVEMENT,
@@ -167,12 +170,11 @@ public final class PlayerConnection implements Listener {
         final World world = event.getSpawnLocation().getWorld();
         final ThreadLocalRandom random = ThreadLocalRandom.current();
 
-        final double teleportAmount = 500000D;
         final Location location = new Location(
             world,
-            random.nextDouble(-teleportAmount, teleportAmount),
-            100,
-            random.nextDouble(-teleportAmount, teleportAmount)
+            random.nextDouble(-RANDOMIZE_SPAWN_RADIUS, RANDOMIZE_SPAWN_RADIUS),
+            RANDOMIZE_SPAWN_Y,
+            random.nextDouble(-RANDOMIZE_SPAWN_RADIUS, RANDOMIZE_SPAWN_RADIUS)
         );
 
         event.setSpawnLocation(location);

--- a/src/main/java/pw/kaboom/extras/modules/player/PlayerConnection.java
+++ b/src/main/java/pw/kaboom/extras/modules/player/PlayerConnection.java
@@ -180,7 +180,7 @@ public final class PlayerConnection implements Listener {
 
     @EventHandler
     void onPlayerQuit(final PlayerQuitEvent event) {
-        PlayerCommand.getCommandMillisList().remove(event.getPlayer().getUniqueId());
+        PlayerCommand.getLastCommandExec().remove(event.getPlayer().getUniqueId());
         //PlayerInteract.interactMillisList.remove(event.getPlayer().getUniqueId());
         ServerTabComplete.getLoginNameList().remove(event.getPlayer().getUniqueId());
     }

--- a/src/main/java/pw/kaboom/extras/modules/player/PlayerConnection.java
+++ b/src/main/java/pw/kaboom/extras/modules/player/PlayerConnection.java
@@ -45,9 +45,16 @@ public final class PlayerConnection implements Listener {
                                 ""
                         )
                 );
-    private static final Duration FADE_IN = Duration.ofMillis(50);
-    private static final Duration STAY = Duration.ofMillis(8000);
-    private static final Duration FADE_OUT = Duration.ofMillis(250);
+    private static final boolean SEND_TITLE = CONFIG.getBoolean("playerJoinSendTitle");
+    private static final Duration FADE_IN = Duration.ofMillis(
+            CONFIG.getLong("playerJoinTitleFadeIn")
+    );
+    private static final Duration STAY = Duration.ofMillis(
+            CONFIG.getLong("playerJoinTitleStay")
+    );
+    private static final Duration FADE_OUT = Duration.ofMillis(
+            CONFIG.getLong("playerJoinTitleFadeOut")
+    );
 
     private static final boolean ENABLE_KICK = CONFIG.getBoolean("enableKick");
     private static final boolean ENABLE_JOIN_RESTRICTIONS = CONFIG.getBoolean(
@@ -102,7 +109,7 @@ public final class PlayerConnection implements Listener {
     void onPlayerJoin(final PlayerJoinEvent event) {
         final Player player = event.getPlayer();
 
-        player.showTitle(Title.title(
+        if (SEND_TITLE) player.showTitle(Title.title(
             TITLE,
             SUBTITLE,
             Title.Times.times(FADE_IN, STAY, FADE_OUT)

--- a/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
+++ b/src/main/java/pw/kaboom/extras/modules/server/ServerCommand.java
@@ -1,6 +1,5 @@
 package pw.kaboom.extras.modules.server;
 
-import com.google.common.collect.ImmutableSet;
 import org.bukkit.block.CommandBlock;
 import org.bukkit.command.BlockCommandSender;
 import org.bukkit.command.CommandSender;
@@ -11,9 +10,7 @@ import org.bukkit.event.server.ServerCommandEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 import pw.kaboom.extras.Main;
 
-import java.util.Arrays;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -21,13 +18,22 @@ import java.util.regex.Pattern;
 
 public final class ServerCommand implements Listener {
     private static final Pattern SELECTOR_PATTERN = Pattern.compile("(?>\\s)*@[aenprs](?>\\s)*");
-    private static final Logger LOGGER = JavaPlugin.getPlugin(Main.class).getLogger();
+    private static final Main PLUGIN = JavaPlugin.getPlugin(Main.class);
+    private static final Logger LOGGER = PLUGIN.getLogger();
 
-    private static final Set<String> BLOCKED_EXECUTE_COMMANDS = ImmutableSet.of(
-            "clone", "fill", "give", "kick", "locate",  "me", "msg", "save-all", "say",
-            "spawnpoint", "spreadplayers",  "summon", "teammsg",  "teleport", "tell", "tellraw",
-            "tm", "tp", "w", "fillbiome", "ride");
-
+    // Must be kept in sync with the blocked execute command list in config.yml
+    @SuppressWarnings("unchecked")
+    private static final Set<String> BLOCKED_EXECUTE_COMMANDS = new HashSet<>(
+            (List<String>)
+                    PLUGIN.getConfig().getList(
+                        "blockedInExecute",
+                        Arrays.asList(
+                            "clone", "fill", "give", "kick", "locate",  "me", "msg", "save-all",
+                            "say", "spawnpoint", "spreadplayers",  "summon", "teammsg", "teleport",
+                            "tell", "tellraw", "tm", "tp", "w", "fillbiome", "ride"
+                    )
+            )
+    );
     private static String checkSelectors(final String[] arr, final int offset) {
         final String[] args = Arrays.copyOfRange(arr, offset, arr.length);
         final String str = String.join(" ", args);
@@ -76,7 +82,8 @@ public final class ServerCommand implements Listener {
                         }
 
                         for (int i = 1; i < arr.length; i++) {
-                            if ("summon".equalsIgnoreCase(arr[i])) {
+                            if (BLOCKED_EXECUTE_COMMANDS.contains("summon")
+                                    && "summon".equalsIgnoreCase(arr[i])) {
                                 return "cancel";
                             }
                             if (!"run".equalsIgnoreCase(arr[i])) {

--- a/src/main/java/pw/kaboom/extras/modules/server/ServerGameRule.java
+++ b/src/main/java/pw/kaboom/extras/modules/server/ServerGameRule.java
@@ -4,8 +4,10 @@ import io.papermc.paper.event.world.WorldGameRuleChangeEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.GameRule;
 import org.bukkit.World;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitScheduler;
 import pw.kaboom.extras.Main;
 import pw.kaboom.extras.modules.entity.EntitySpawn;
@@ -13,15 +15,21 @@ import pw.kaboom.extras.modules.entity.EntitySpawn;
 import java.util.Map;
 
 public final class ServerGameRule implements Listener {
+    private static final FileConfiguration CONFIG = JavaPlugin.getPlugin(Main.class).getConfig();
+
     private static final Map<GameRule<?>, ?> FORCED_GAMERULES = Map.of(
-        GameRule.COMMAND_BLOCKS_ENABLED, true,
-        GameRule.SPAWNER_BLOCKS_ENABLED, false
+        GameRule.COMMAND_BLOCKS_ENABLED, CONFIG.getBoolean("forceCommandBlocksTo"),
+        GameRule.SPAWNER_BLOCKS_ENABLED, CONFIG.getBoolean("forceSpawnerBlocksTo")
     );
 
+    // TODO: Dynamic gamerule limits
     private static final Map<GameRule<Integer>, Integer> GAMERULE_LIMITS = Map.of(
-            GameRule.RANDOM_TICK_SPEED, 6,
-            GameRule.SPAWN_RADIUS, 100,
-            GameRule.COMMAND_MODIFICATION_BLOCK_LIMIT, 32768,
+            GameRule.RANDOM_TICK_SPEED, CONFIG.getInt("maxTickSpeed"),
+            GameRule.SPAWN_RADIUS, CONFIG.getInt("maxSpawnRadius"),
+
+            GameRule.COMMAND_MODIFICATION_BLOCK_LIMIT,
+            CONFIG.getInt("maxCommandModificationBlockLimit"),
+
             GameRule.MAX_COMMAND_FORK_COUNT, EntitySpawn.MAX_ENTITIES_PER_WORLD
     );
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -16,6 +16,9 @@ maxWithersPerWorld: 128
 maxTntMinecartsPerWorld: 80
 maxFireballCount: 30
 maxExplosionRadius: 20
+spawnerMinSpawnDelay: 1000
+spawnerMaxSpawnCount: 200
+spawnerMaxSpawnRange: 50
 generateFlatlands: true
 playerJoinSendTitle: true
 playerJoinTitle: "§7Welcome to Kaboom!"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -20,3 +20,4 @@ playerJoinTitleFadeOut: 50
 opTag: "§4§l[§c§lOP§4§l] §c"
 deOpTag: "§8§l[§7§lDeOP§8§l] §7"
 minCommandDelayMillis: 75
+minChatDelayMillis: 50

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -12,6 +12,7 @@ maxEntitiesPerChunk: 50
 maxEntitiesPerWorld: 5120
 maxTntsPerWorld: 1024
 maxDragonsPerWorld: 24
+maxWithersPerWorld: 128
 generateFlatlands: true
 playerJoinSendTitle: true
 playerJoinTitle: "§7Welcome to Kaboom!"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -11,6 +11,7 @@ randomizeSpawn: false
 maxEntitiesPerChunk: 50
 maxEntitiesPerWorld: 5120
 maxTntsPerWorld: 1024
+generateFlatlands: true
 playerJoinSendTitle: true
 playerJoinTitle: "§7Welcome to Kaboom!"
 playerJoinSubtitle: "Free OP • Anarchy • Creative"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -11,7 +11,11 @@ randomizeSpawn: false
 maxEntitiesPerChunk: 50
 maxEntitiesPerWorld: 5120
 maxTntsPerWorld: 1024
+playerJoinSendTitle: true
 playerJoinTitle: "§7Welcome to Kaboom!"
 playerJoinSubtitle: "Free OP • Anarchy • Creative"
+playerJoinTitleFadeIn: 50
+playerJoinTitleStay: 8000
+playerJoinTitleFadeOut: 50
 opTag: "§4§l[§c§lOP§4§l] §c"
 deOpTag: "§8§l[§7§lDeOP§8§l] §7"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,6 +13,7 @@ maxEntitiesPerWorld: 5120
 maxTntsPerWorld: 1024
 maxDragonsPerWorld: 24
 maxWithersPerWorld: 128
+maxTntMinecartsPerWorld: 80
 maxFireballCount: 30
 maxExplosionRadius: 20
 generateFlatlands: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,6 +13,8 @@ maxEntitiesPerWorld: 5120
 maxTntsPerWorld: 1024
 maxDragonsPerWorld: 24
 maxWithersPerWorld: 128
+maxFireballCount: 30
+maxExplosionRadius: 20
 generateFlatlands: true
 playerJoinSendTitle: true
 playerJoinTitle: "§7Welcome to Kaboom!"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -19,6 +19,9 @@ maxExplosionRadius: 20
 spawnerMinSpawnDelay: 1000
 spawnerMaxSpawnCount: 200
 spawnerMaxSpawnRange: 50
+effectCloudMaxRadius: 40
+effectCloudMaxRadiusOnUse: 0.01
+effectCloudMaxRadiusPerTick: 0
 generateFlatlands: true
 playerJoinSendTitle: true
 playerJoinTitle: "§7Welcome to Kaboom!"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -23,6 +23,7 @@ effectCloudMaxRadius: 40
 effectCloudMaxRadiusOnUse: 0.01
 effectCloudMaxRadiusPerTick: 0
 maxSlimeSize: 20
+maxKnockbackVelocity: 20
 generateFlatlands: true
 playerJoinSendTitle: true
 playerJoinTitle: "§7Welcome to Kaboom!"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -26,6 +26,11 @@ effectCloudMaxRadiusOnUse: 0.01
 effectCloudMaxRadiusPerTick: 0
 maxSlimeSize: 20
 maxKnockbackVelocity: 20
+forceCommandBlocksTo: true
+forceSpawnerBlocksTo: false
+maxTickSpeed: 6
+maxSpawnRadius: 100
+maxCommandModificationBlockLimit: 32768
 generateFlatlands: true
 playerJoinSendTitle: true
 playerJoinTitle: "§7Welcome to Kaboom!"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -22,3 +22,25 @@ opTag: "§4§l[§c§lOP§4§l] §c"
 deOpTag: "§8§l[§7§lDeOP§8§l] §7"
 minCommandDelayMillis: 75
 minChatDelayMillis: 50
+blockedInExecute:
+  - clone
+  - fill
+  - give
+  - kick
+  - locate
+  - me
+  - msg
+  - save-all
+  - say
+  - spawnpoint
+  - spreadplayers
+  - summon
+  - teammsg
+  - teleport
+  - tell
+  - tellraw
+  - tm
+  - tp
+  - w
+  - fillbiome
+  - ride

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -22,6 +22,7 @@ spawnerMaxSpawnRange: 50
 effectCloudMaxRadius: 40
 effectCloudMaxRadiusOnUse: 0.01
 effectCloudMaxRadiusPerTick: 0
+maxSlimeSize: 20
 generateFlatlands: true
 playerJoinSendTitle: true
 playerJoinTitle: "§7Welcome to Kaboom!"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -22,6 +22,7 @@ opTag: "§4§l[§c§lOP§4§l] §c"
 deOpTag: "§8§l[§7§lDeOP§8§l] §7"
 minCommandDelayMillis: 75
 minChatDelayMillis: 50
+maxPrefixLength: 1024
 blockedInExecute:
   - clone
   - fill

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -8,6 +8,8 @@ opOnJoin: true
 # versions.
 # You can use the pre-world generation plugin "Chunky" to achieve this.
 randomizeSpawn: false
+randomizeSpawnRadius: 500000
+randomizeSpawnY: 100
 maxEntitiesPerChunk: 50
 maxEntitiesPerWorld: 5120
 maxTntsPerWorld: 1024

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -11,6 +11,7 @@ randomizeSpawn: false
 maxEntitiesPerChunk: 50
 maxEntitiesPerWorld: 5120
 maxTntsPerWorld: 1024
+maxDragonsPerWorld: 24
 generateFlatlands: true
 playerJoinSendTitle: true
 playerJoinTitle: "§7Welcome to Kaboom!"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -19,3 +19,4 @@ playerJoinTitleStay: 8000
 playerJoinTitleFadeOut: 50
 opTag: "§4§l[§c§lOP§4§l] §c"
 deOpTag: "§8§l[§7§lDeOP§8§l] §7"
+minCommandDelayMillis: 75


### PR DESCRIPTION
[Configurate]: https://github.com/SpongePowered/Configurate
[ObjectMapperExample.java]: https://github.com/SpongePowered/Configurate/blob/033bdf8d757fdb96959b313ed2d7c578252d9cd9/examples/src/main/java/org/spongepowered/configurate/examples/ObjectMapperExample.java#L65
[SpigotMC.org#plugin.yml]: https://www.spigotmc.org/wiki/plugin-yml

I've marked this as a draft PR because I feel the amount of additions to config.yml leaves a lot to be desired. Ideally, everything related would be grouped into its own sections (i.e. entity limits and gamerule limits would be in `limits.entity` and `limits.gamerule` respectively), but that would require configuration migration if we don't want to break existing deployments which have branched off from our configuration yet still use our version of Extras.

However, I don't really want to write those migrations with Bukkit's FileConfiguration API, because it really sucks when you've been using [Configurate] in basically all of your Java projects. See the [ObjectMapperExample.java] for why I think it's much better than FileConfiguration.

Unfortunately, Configurate is not included in Paper, so it would have to be added as a dependency and I know that you don't really want that. I guess I'll have to find another way to make configuration tolerable if we can't depend on Configurate. Also, we wouldn't need to include it with shading - we can instead declare the library in plugin.yml (see the libraries section of [SpigotMC.org#plugin.yml]) and it'll be downloaded at runtime & cached for later use. Not too much of a big deal considering you need an Internet connection for the initial server run anyways. However, transitive dependencies (i.e. dependencies of dependencies and further down the dependency tree) might have to be manually added, although I'm not entirely sure.

Also, note that you shouldn't add the blockedInExecute to the Extras config.yml in the server repo, otherwise it will override it. Instead, don't specify it at all and it will be kept in sync with the version in the plugin.