### PR TITLE
Generate a lot of blocks above 0 in the Flatlands

### DIFF
--- a/src/main/java/pw/kaboom/extras/Main.java
+++ b/src/main/java/pw/kaboom/extras/Main.java
@@ -1,5 +1,6 @@
 package pw.kaboom.extras;
 
+import io.papermc.paper.registry.keys.BlockTypeKeys;
 import org.bukkit.WorldCreator;
 import org.bukkit.WorldType;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -17,6 +18,7 @@ import pw.kaboom.extras.modules.player.skin.SkinManager;
 import pw.kaboom.extras.modules.server.ServerCommand;
 import pw.kaboom.extras.modules.server.ServerGameRule;
 import pw.kaboom.extras.modules.server.ServerTabComplete;
+import pw.kaboom.extras.util.FlatLayers;
 
 import java.io.File;
 
@@ -99,7 +101,17 @@ public final class Main extends JavaPlugin {
 
         /* Custom worlds */
         this.getServer().createWorld(
-            new WorldCreator("world_flatlands").generateStructures(false).type(WorldType.FLAT)
+            new WorldCreator("world_flatlands")
+                    .generateStructures(false)
+                    .type(WorldType.FLAT)
+                    .generatorSettings(
+                            new FlatLayers()
+                                    .addLayer(BlockTypeKeys.BEDROCK, 1)
+                                    .addLayer(BlockTypeKeys.DIRT, 124)
+                                    .addLayer(BlockTypeKeys.STONE, 2)
+                                    .addLayer(BlockTypeKeys.GRASS_BLOCK, 1)
+                                    .build()
+                    )
         );
 
         final Messenger messenger = this.getServer().getMessenger();

--- a/src/main/java/pw/kaboom/extras/util/FlatLayers.java
+++ b/src/main/java/pw/kaboom/extras/util/FlatLayers.java
@@ -1,0 +1,27 @@
+package pw.kaboom.extras.util;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import io.papermc.paper.registry.TypedKey;
+import org.bukkit.block.BlockType;
+
+public final class FlatLayers {
+    private final JsonArray layers = new JsonArray();
+
+    public FlatLayers addLayer(final TypedKey<BlockType> blockType,
+                               final int height) {
+        final var layer = new JsonObject();
+
+        layer.addProperty("block", blockType.asString());
+        layer.addProperty("height", height);
+
+        this.layers.add(layer);
+        return this;
+    }
+
+    public String build() {
+        final var layers = new JsonObject();
+        layers.add("layers", this.layers);
+        return layers.toString();
+    }
+}


### PR DESCRIPTION
People on older clients where the minimum Y is 0 currently can't see anything in the Flatlands.

Unfortunately, changing the flatlands to generate with the old minimum Y and height requires the following steps:

1. Convert to paper plugin
2. Convert all commands to Paper brigadier commands
3. Create a datapack
4. Register our datapack in a Paper plugin bootstrap class
5. Define a custom dimension type (so we can define the min y and height)
6. Define a custom dimension with its type set to our dimension type (so that it actually generates)
7. Define custom noise settings so we can set the sea level so the Flatlands won't look horrid on new clients
8. Sea level doesn't even change... Wtf?

I can't be bothered to figure out how to do all that in a working and concise matter, so this should do for now.