### PR TITLE
Avoid retrieving entity list for world limit check

### DIFF
--- a/src/main/java/pw/kaboom/extras/modules/entity/EntitySpawn.java
+++ b/src/main/java/pw/kaboom/extras/modules/entity/EntitySpawn.java
@@ -51,7 +51,7 @@ public final class EntitySpawn implements Listener {
     }
 
     private boolean checkShouldRemoveEntities(final World world) {
-        final int worldEntityCount = world.getEntities().size();
+        final int worldEntityCount = world.getEntityCount();
 
         if (worldEntityCount > MAX_ENTITIES_PER_WORLD) {
             for (Entity entity : world.getEntities()) {


### PR DESCRIPTION
Use `World#getEntityCount()` when checking the global entity limit. This avoids retrieving the world's complete entity list for every entity spawn. The list is still retrieved when the limit is exceeded and entities need to be removed